### PR TITLE
Add Taginfo-based alternative to tag comparison map

### DIFF
--- a/OSM_regions.json
+++ b/OSM_regions.json
@@ -12,235 +12,274 @@
           "name": "Algeria",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/algeria",
-          "subregions": []
+          "subregions": [],
+          "iso": "DZ"
         },
         {
           "name": "Angola",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/angola",
-          "subregions": []
+          "subregions": [],
+          "iso": "AO"
         },
         {
           "name": "Benin",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/benin",
-          "subregions": []
+          "subregions": [],
+          "iso": "BJ"
         },
         {
           "name": "Botswana",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/botswana",
-          "subregions": []
+          "subregions": [],
+          "iso": "BW"
         },
         {
           "name": "Burkina Faso",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/burkina-faso",
-          "subregions": []
+          "subregions": [],
+          "iso": "BF"
         },
         {
           "name": "Burundi",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/burundi",
-          "subregions": []
+          "subregions": [],
+          "iso": "BI"
         },
         {
           "name": "Cameroon",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/cameroon",
-          "subregions": []
+          "subregions": [],
+          "iso": "CM"
         },
         {
           "name": "Canary Islands",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/canary-islands",
-          "subregions": []
+          "subregions": [],
+          "iso": "ES-CN"
         },
         {
           "name": "Cape Verde",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/cape-verde",
-          "subregions": []
+          "subregions": [],
+          "iso": "CV"
         },
         {
           "name": "Central African Republic",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/central-african-republic",
-          "subregions": []
+          "subregions": [],
+          "iso": "CF"
         },
         {
           "name": "Chad",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/chad",
-          "subregions": []
+          "subregions": [],
+          "iso": "TD"
         },
         {
           "name": "Comores",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/comores",
-          "subregions": []
+          "subregions": [],
+          "iso": "KM"
         },
         {
           "name": "Congo (Republic/Brazzaville)",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/congo-brazzaville",
-          "subregions": []
+          "subregions": [],
+          "iso": "CG"
         },
         {
           "name": "Congo (Democratic Republic/Kinshasa)",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/congo-democratic-republic",
-          "subregions": []
+          "subregions": [],
+          "iso": "CD"
         },
         {
           "name": "Djibouti",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/djibouti",
-          "subregions": []
+          "subregions": [],
+          "iso": "DJ"
         },
         {
           "name": "Egypt",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/egypt",
-          "subregions": []
+          "subregions": [],
+          "iso": "EG"
         },
         {
           "name": "Equatorial Guinea",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/equatorial-guinea",
-          "subregions": []
+          "subregions": [],
+          "iso": "GQ"
         },
         {
           "name": "Eritrea",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/eritrea",
-          "subregions": []
+          "subregions": [],
+          "iso": "ER"
         },
         {
           "name": "Ethiopia",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/ethiopia",
-          "subregions": []
+          "subregions": [],
+          "iso": "ET"
         },
         {
           "name": "Gabon",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/gabon",
-          "subregions": []
+          "subregions": [],
+          "iso": "GA"
         },
         {
           "name": "Ghana",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/ghana",
-          "subregions": []
+          "subregions": [],
+          "iso": "GH"
         },
         {
           "name": "Guinea",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/guinea",
-          "subregions": []
+          "subregions": [],
+          "iso": "GN"
         },
         {
           "name": "Guinea-Bissau",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/guinea-bissau",
-          "subregions": []
+          "subregions": [],
+          "iso": "GW"
         },
         {
           "name": "Ivory Coast",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/ivory-coast",
-          "subregions": []
+          "subregions": [],
+          "iso": "CI"
         },
         {
           "name": "Kenya",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/kenya",
-          "subregions": []
+          "subregions": [],
+          "iso": "KE"
         },
         {
           "name": "Lesotho",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/lesotho",
-          "subregions": []
+          "subregions": [],
+          "iso": "LS"
         },
         {
           "name": "Liberia",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/liberia",
-          "subregions": []
+          "subregions": [],
+          "iso": "LR"
         },
         {
           "name": "Libya",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/libya",
-          "subregions": []
+          "subregions": [],
+          "iso": "LY"
         },
         {
           "name": "Madagascar",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/madagascar",
-          "subregions": []
+          "subregions": [],
+          "iso": "MG"
         },
         {
           "name": "Malawi",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/malawi",
-          "subregions": []
+          "subregions": [],
+          "iso": "MW"
         },
         {
           "name": "Mali",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/mali",
-          "subregions": []
+          "subregions": [],
+          "iso": "ML"
         },
         {
           "name": "Mauritania",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/mauritania",
-          "subregions": []
+          "subregions": [],
+          "iso": "MR"
         },
         {
           "name": "Mauritius",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/mauritius",
-          "subregions": []
+          "subregions": [],
+          "iso": "MU"
         },
         {
           "name": "Morocco",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/morocco",
-          "subregions": []
+          "subregions": [],
+          "iso": "MA"
         },
         {
           "name": "Mozambique",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/mozambique",
-          "subregions": []
+          "subregions": [],
+          "iso": "MZ"
         },
         {
           "name": "Namibia",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/namibia",
-          "subregions": []
+          "subregions": [],
+          "iso": "NA"
         },
         {
           "name": "Niger",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/niger",
-          "subregions": []
+          "subregions": [],
+          "iso": "NE"
         },
         {
           "name": "Nigeria",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/nigeria",
-          "subregions": []
+          "subregions": [],
+          "iso": "NG"
         },
         {
           "name": "Rwanda",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/rwanda",
-          "subregions": []
+          "subregions": [],
+          "iso": "RW"
         },
         {
           "name": "Saint Helena, Ascension, and Tristan da Cunha",
@@ -264,25 +303,29 @@
           "name": "Seychelles",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/seychelles",
-          "subregions": []
+          "subregions": [],
+          "iso": "SC"
         },
         {
           "name": "Sierra Leone",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/sierra-leone",
-          "subregions": []
+          "subregions": [],
+          "iso": "SL"
         },
         {
           "name": "Somalia",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/somalia",
-          "subregions": []
+          "subregions": [],
+          "iso": "SO"
         },
         {
           "name": "South Africa",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/south-africa",
-          "subregions": []
+          "subregions": [],
+          "iso": "ZA"
         },
         {
           "name": "South Africa (includes Lesotho)",
@@ -294,55 +337,64 @@
           "name": "South Sudan",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/south-sudan",
-          "subregions": []
+          "subregions": [],
+          "iso": "SS"
         },
         {
           "name": "Sudan",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/sudan",
-          "subregions": []
+          "subregions": [],
+          "iso": "SD"
         },
         {
           "name": "Swaziland",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/swaziland",
-          "subregions": []
+          "subregions": [],
+          "iso": "SZ"
         },
         {
           "name": "Zambia",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/zambia",
-          "subregions": []
+          "subregions": [],
+          "iso": "ZM"
         },
         {
           "name": "Zimbabwe",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/zimbabwe",
-          "subregions": []
+          "subregions": [],
+          "iso": "ZW"
         },
         {
           "name": "Tanzania",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/tanzania",
-          "subregions": []
+          "subregions": [],
+          "iso": "TZ"
         },
         {
           "name": "Togo",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/togo",
-          "subregions": []
+          "subregions": [],
+          "iso": "TG"
         },
         {
           "name": "Tunisia",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/tunisia",
-          "subregions": []
+          "subregions": [],
+          "iso": "TN"
         },
         {
           "name": "Uganda",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/africa/uganda",
-          "subregions": []
+          "subregions": [],
+          "iso": "UG"
         }
       ]
     },
@@ -350,7 +402,8 @@
       "name": "Antarctica",
       "admin_level": 1,
       "taginfo_url": "https://taginfo.geofabrik.de/antarctica",
-      "subregions": []
+      "subregions": [],
+      "iso": "AQ"
     },
     {
       "name": "Asia",
@@ -361,43 +414,50 @@
           "name": "Afghanistan",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/asia/afghanistan",
-          "subregions": []
+          "subregions": [],
+          "iso": "AF"
         },
         {
           "name": "Armenia",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/asia/armenia",
-          "subregions": []
+          "subregions": [],
+          "iso": "AM"
         },
         {
           "name": "Azerbaijan",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/asia/azerbaijan",
-          "subregions": []
+          "subregions": [],
+          "iso": "AZ"
         },
         {
           "name": "Bangladesh",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/asia/bangladesh",
-          "subregions": []
+          "subregions": [],
+          "iso": "BD"
         },
         {
           "name": "Bhutan",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/asia/bhutan",
-          "subregions": []
+          "subregions": [],
+          "iso": "BT"
         },
         {
           "name": "Cambodia",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/asia/cambodia",
-          "subregions": []
+          "subregions": [],
+          "iso": "KH"
         },
         {
           "name": "China",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/asia/china",
-          "subregions": []
+          "subregions": [],
+          "iso": "CN"
         },
         {
           "name": "GCC States",
@@ -409,25 +469,29 @@
           "name": "India",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/asia/india",
-          "subregions": []
+          "subregions": [],
+          "iso": "IN"
         },
         {
           "name": "Indonesia",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/asia/indonesia",
-          "subregions": []
+          "subregions": [],
+          "iso": "ID"
         },
         {
           "name": "Iran",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/asia/iran",
-          "subregions": []
+          "subregions": [],
+          "iso": "IR"
         },
         {
           "name": "Iraq",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/asia/iraq",
-          "subregions": []
+          "subregions": [],
+          "iso": "IQ"
         },
         {
           "name": "Israel and Palestine",
@@ -456,7 +520,8 @@
               "name": "Hokkaidō",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/asia/japan/hokkaido",
-              "subregions": []
+              "subregions": [],
+              "iso": "JP-01"
             },
             {
               "name": "Kansai region (a.k.a. Kinki region)",
@@ -488,37 +553,43 @@
               "taginfo_url": "https://taginfo.geofabrik.de/asia/japan/tohoku",
               "subregions": []
             }
-          ]
+          ],
+          "iso": "JP"
         },
         {
           "name": "Jordan",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/asia/jordan",
-          "subregions": []
+          "subregions": [],
+          "iso": "JO"
         },
         {
           "name": "Kazakhstan",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/asia/kazakhstan",
-          "subregions": []
+          "subregions": [],
+          "iso": "KZ"
         },
         {
           "name": "Kyrgyzstan",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/asia/kyrgyzstan",
-          "subregions": []
+          "subregions": [],
+          "iso": "KG"
         },
         {
           "name": "Laos",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/asia/laos",
-          "subregions": []
+          "subregions": [],
+          "iso": "LA"
         },
         {
           "name": "Lebanon",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/asia/lebanon",
-          "subregions": []
+          "subregions": [],
+          "iso": "LB"
         },
         {
           "name": "Malaysia, Singapore, and Brunei",
@@ -530,103 +601,120 @@
           "name": "Maldives",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/asia/maldives",
-          "subregions": []
+          "subregions": [],
+          "iso": "MV"
         },
         {
           "name": "Mongolia",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/asia/mongolia",
-          "subregions": []
+          "subregions": [],
+          "iso": "MN"
         },
         {
           "name": "Myanmar (a.k.a. Burma)",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/asia/myanmar",
-          "subregions": []
+          "subregions": [],
+          "iso": "MM"
         },
         {
           "name": "Nepal",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/asia/nepal",
-          "subregions": []
+          "subregions": [],
+          "iso": "NP"
         },
         {
           "name": "North Korea",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/asia/north-korea",
-          "subregions": []
+          "subregions": [],
+          "iso": "KP"
         },
         {
           "name": "Pakistan",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/asia/pakistan",
-          "subregions": []
+          "subregions": [],
+          "iso": "PK"
         },
         {
           "name": "Philippines",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/asia/philippines",
-          "subregions": []
+          "subregions": [],
+          "iso": "PH"
         },
         {
           "name": "South Korea",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/asia/south-korea",
-          "subregions": []
+          "subregions": [],
+          "iso": "KR"
         },
         {
           "name": "Sri Lanka",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/asia/sri-lanka",
-          "subregions": []
+          "subregions": [],
+          "iso": "LK"
         },
         {
           "name": "Syria",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/asia/syria",
-          "subregions": []
+          "subregions": [],
+          "iso": "SY"
         },
         {
           "name": "Taiwan",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/asia/taiwan",
-          "subregions": []
+          "subregions": [],
+          "iso": "TW"
         },
         {
           "name": "Tajikistan",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/asia/tajikistan",
-          "subregions": []
+          "subregions": [],
+          "iso": "TJ"
         },
         {
           "name": "Thailand",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/asia/thailand",
-          "subregions": []
+          "subregions": [],
+          "iso": "TH"
         },
         {
           "name": "Turkmenistan",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/asia/turkmenistan",
-          "subregions": []
+          "subregions": [],
+          "iso": "TM"
         },
         {
           "name": "Uzbekistan",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/asia/uzbekistan",
-          "subregions": []
+          "subregions": [],
+          "iso": "UZ"
         },
         {
           "name": "Vietnam",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/asia/vietnam",
-          "subregions": []
+          "subregions": [],
+          "iso": "VN"
         },
         {
           "name": "Yemen",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/asia/yemen",
-          "subregions": []
+          "subregions": [],
+          "iso": "YE"
         }
       ]
     },
@@ -639,31 +727,36 @@
           "name": "Australia",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/australia-oceania/australia",
-          "subregions": []
+          "subregions": [],
+          "iso": "AU"
         },
         {
           "name": "Fiji",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/australia-oceania/fiji",
-          "subregions": []
+          "subregions": [],
+          "iso": "FJ"
         },
         {
           "name": "New Caledonia",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/australia-oceania/new-caledonia",
-          "subregions": []
+          "subregions": [],
+          "iso": "NC"
         },
         {
           "name": "New Zealand",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/australia-oceania/new-zealand",
-          "subregions": []
+          "subregions": [],
+          "iso": "NZ"
         },
         {
           "name": "Papua New Guinea",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/australia-oceania/papua-new-guinea",
-          "subregions": []
+          "subregions": [],
+          "iso": "PG"
         }
       ]
     },
@@ -676,25 +769,29 @@
           "name": "Bahamas",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/central-america/bahamas",
-          "subregions": []
+          "subregions": [],
+          "iso": "BS"
         },
         {
           "name": "Belize",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/central-america/belize",
-          "subregions": []
+          "subregions": [],
+          "iso": "BZ"
         },
         {
           "name": "Cuba",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/central-america/cuba",
-          "subregions": []
+          "subregions": [],
+          "iso": "CU"
         },
         {
           "name": "Guatemala",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/central-america/guatemala",
-          "subregions": []
+          "subregions": [],
+          "iso": "GT"
         },
         {
           "name": "Haiti and Dominican Republic",
@@ -706,13 +803,15 @@
           "name": "Jamaica",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/central-america/jamaica",
-          "subregions": []
+          "subregions": [],
+          "iso": "JM"
         },
         {
           "name": "Nicaragua",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/central-america/nicaragua",
-          "subregions": []
+          "subregions": [],
+          "iso": "NI"
         }
       ]
     },
@@ -725,7 +824,8 @@
           "name": "Albania",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/albania",
-          "subregions": []
+          "subregions": [],
+          "iso": "AL"
         },
         {
           "name": "Alps",
@@ -737,37 +837,43 @@
           "name": "Andorra",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/andorra",
-          "subregions": []
+          "subregions": [],
+          "iso": "AD"
         },
         {
           "name": "Azores",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/azores",
-          "subregions": []
+          "subregions": [],
+          "iso": "PT-20"
         },
         {
           "name": "Austria",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/austria",
-          "subregions": []
+          "subregions": [],
+          "iso": "AT"
         },
         {
           "name": "Belarus",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/belarus",
-          "subregions": []
+          "subregions": [],
+          "iso": "BY"
         },
         {
           "name": "Belgium",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/belgium",
-          "subregions": []
+          "subregions": [],
+          "iso": "BE"
         },
         {
           "name": "Bosnia-Herzegovina",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/bosnia-herzegovina",
-          "subregions": []
+          "subregions": [],
+          "iso": "BA"
         },
         {
           "name": "Britain and Ireland",
@@ -779,49 +885,63 @@
           "name": "Bulgaria",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/bulgaria",
-          "subregions": []
+          "subregions": [],
+          "iso": "BG"
         },
         {
           "name": "Croatia",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/croatia",
-          "subregions": []
+          "subregions": [],
+          "iso": "HR"
         },
         {
           "name": "Czech Republic",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/czech-republic",
-          "subregions": []
+          "subregions": [],
+          "iso": "CZ"
         },
         {
           "name": "Cyprus",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/cyprus",
+          "subregions": [],
+          "iso": "CY"
+        },
+        {
+          "name": "Germany, Austria, Switzerland",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/dach",
           "subregions": []
         },
         {
           "name": "Denmark",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/denmark",
-          "subregions": []
+          "subregions": [],
+          "iso": "DK"
         },
         {
           "name": "Estonia",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/estonia",
-          "subregions": []
+          "subregions": [],
+          "iso": "EE"
         },
         {
           "name": "Faroe Islands",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/faroe-islands",
-          "subregions": []
+          "subregions": [],
+          "iso": "FO"
         },
         {
           "name": "Finland",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/finland",
-          "subregions": []
+          "subregions": [],
+          "iso": "FI"
         },
         {
           "name": "France",
@@ -832,171 +952,200 @@
               "name": "Alsace",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/france/alsace",
-              "subregions": []
+              "subregions": [],
+              "iso": "FR-A"
             },
             {
               "name": "Aquitaine",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/france/aquitaine",
-              "subregions": []
+              "subregions": [],
+              "iso": "FR-B"
             },
             {
               "name": "Auvergne",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/france/auvergne",
-              "subregions": []
+              "subregions": [],
+              "iso": "FR-C"
             },
             {
               "name": "Basse-Normandie",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/france/basse-normandie",
-              "subregions": []
+              "subregions": [],
+              "iso": "FR-P"
             },
             {
               "name": "Bourgogne",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/france/bourgogne",
-              "subregions": []
+              "subregions": [],
+              "iso": "FR-D"
             },
             {
               "name": "Bretagne",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/france/bretagne",
-              "subregions": []
+              "subregions": [],
+              "iso": "FR-E"
             },
             {
               "name": "Centre",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/france/centre",
-              "subregions": []
+              "subregions": [],
+              "iso": "FR-F"
             },
             {
               "name": "Champagne Ardenne",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/france/champagne-ardenne",
-              "subregions": []
+              "subregions": [],
+              "iso": "FR-G"
             },
             {
               "name": "Corse",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/france/corse",
-              "subregions": []
+              "subregions": [],
+              "iso": "FR-H"
             },
             {
               "name": "Franche Comte",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/france/franche-comte",
-              "subregions": []
+              "subregions": [],
+              "iso": "FR-I"
             },
             {
               "name": "Guadeloupe",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/france/guadeloupe",
-              "subregions": []
+              "subregions": [],
+              "iso": "FR-GP"
             },
             {
               "name": "Guyane",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/france/guyane",
-              "subregions": []
+              "subregions": [],
+              "iso": "FR-GF"
             },
             {
               "name": "Haute-Normandie",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/france/haute-normandie",
-              "subregions": []
+              "subregions": [],
+              "iso": "FR-Q"
             },
             {
               "name": "Ile-de-France",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/france/ile-de-france",
-              "subregions": []
+              "subregions": [],
+              "iso": "FR-J"
             },
             {
               "name": "Languedoc-Roussillon",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/france/languedoc-roussillon",
-              "subregions": []
+              "subregions": [],
+              "iso": "FR-K"
             },
             {
               "name": "Limousin",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/france/limousin",
-              "subregions": []
+              "subregions": [],
+              "iso": "FR-L"
             },
             {
               "name": "Lorraine",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/france/lorraine",
-              "subregions": []
+              "subregions": [],
+              "iso": "FR-M"
             },
             {
               "name": "Martinique",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/france/martinique",
-              "subregions": []
+              "subregions": [],
+              "iso": "FR-MQ"
             },
             {
               "name": "Mayotte",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/france/mayotte",
-              "subregions": []
+              "subregions": [],
+              "iso": "FR-YT"
             },
             {
               "name": "Midi-Pyrenees",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/france/midi-pyrenees",
-              "subregions": []
+              "subregions": [],
+              "iso": "FR-N"
             },
             {
               "name": "Nord-Pas-de-Calais",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/france/nord-pas-de-calais",
-              "subregions": []
+              "subregions": [],
+              "iso": "FR-O"
             },
             {
               "name": "Pays de la Loire",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/france/pays-de-la-loire",
-              "subregions": []
+              "subregions": [],
+              "iso": "FR-R"
             },
             {
               "name": "Picardie",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/france/picardie",
-              "subregions": []
+              "subregions": [],
+              "iso": "FR-S"
             },
             {
               "name": "Poitou-Charentes",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/france/poitou-charentes",
-              "subregions": []
+              "subregions": [],
+              "iso": "FR-T"
             },
             {
               "name": "Provence Alpes-Cote-d'Azur",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/france/provence-alpes-cote-d-azur",
-              "subregions": []
+              "subregions": [],
+              "iso": "FR-U"
             },
             {
               "name": "Reunion",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/france/reunion",
-              "subregions": []
+              "subregions": [],
+              "iso": "FR-RE"
             },
             {
               "name": "Rhone-Alpes",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/france/rhone-alpes",
-              "subregions": []
+              "subregions": [],
+              "iso": "FR-V"
             }
-          ]
+          ],
+          "iso": "FR"
         },
         {
           "name": "Georgia (Eastern Europe)",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/georgia",
-          "subregions": []
+          "subregions": [],
+          "iso": "GE"
         },
         {
           "name": "Germany",
@@ -1007,99 +1156,116 @@
               "name": "Baden-Württemberg",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/baden-wuerttemberg",
-              "subregions": []
+              "subregions": [],
+              "iso": "DE-BW"
             },
             {
               "name": "Bayern",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/bayern",
-              "subregions": []
+              "subregions": [],
+              "iso": "DE-BY"
             },
             {
               "name": "Berlin",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/berlin",
-              "subregions": []
+              "subregions": [],
+              "iso": "DE-BE"
             },
             {
               "name": "Brandenburg (mit Berlin)",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/brandenburg",
-              "subregions": []
+              "subregions": [],
+              "iso": "DE-BB"
             },
             {
               "name": "Bremen",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/bremen",
-              "subregions": []
+              "subregions": [],
+              "iso": "DE-HB"
             },
             {
               "name": "Hamburg",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/hamburg",
-              "subregions": []
+              "subregions": [],
+              "iso": "DE-HH"
             },
             {
               "name": "Hessen",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/hessen",
-              "subregions": []
+              "subregions": [],
+              "iso": "DE-HE"
             },
             {
               "name": "Mecklenburg-Vorpommern",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/mecklenburg-vorpommern",
-              "subregions": []
+              "subregions": [],
+              "iso": "DE-MV"
             },
             {
               "name": "Niedersachsen",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/niedersachsen",
-              "subregions": []
+              "subregions": [],
+              "iso": "DE-NI"
             },
             {
               "name": "Nordrhein-Westfalen",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/nordrhein-westfalen",
-              "subregions": []
+              "subregions": [],
+              "iso": "DE-NW"
             },
             {
               "name": "Rheinland-Pfalz",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/rheinland-pfalz",
-              "subregions": []
+              "subregions": [],
+              "iso": "DE-RP"
             },
             {
               "name": "Saarland",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/saarland",
-              "subregions": []
+              "subregions": [],
+              "iso": "DE-SL"
             },
             {
               "name": "Sachsen",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/sachsen",
-              "subregions": []
+              "subregions": [],
+              "iso": "DE-SN"
             },
             {
               "name": "Sachsen-Anhalt",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/sachsen-anhalt",
-              "subregions": []
+              "subregions": [],
+              "iso": "DE-ST"
             },
             {
               "name": "Schleswig-Holstein",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/schleswig-holstein",
-              "subregions": []
+              "subregions": [],
+              "iso": "DE-SH"
             },
             {
               "name": "Thüringen",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/thueringen",
-              "subregions": []
+              "subregions": [],
+              "iso": "DE-TH"
             }
-          ]
+          ],
+          "iso": "DE"
         },
         {
           "name": "Great Britain",
@@ -1110,51 +1276,60 @@
               "name": "England",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england",
-              "subregions": []
+              "subregions": [],
+              "iso": "GB-ENG"
             },
             {
               "name": "Scotland",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/scotland",
-              "subregions": []
+              "subregions": [],
+              "iso": "GB-SCT"
             },
             {
               "name": "Wales",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/wales",
-              "subregions": []
+              "subregions": [],
+              "iso": "GB-WLS"
             }
-          ]
+          ],
+          "iso": "GB"
         },
         {
           "name": "Greece",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/greece",
-          "subregions": []
+          "subregions": [],
+          "iso": "GR"
         },
         {
           "name": "Hungary",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/hungary",
-          "subregions": []
+          "subregions": [],
+          "iso": "HU"
         },
         {
           "name": "Iceland",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/iceland",
-          "subregions": []
+          "subregions": [],
+          "iso": "IS"
         },
         {
           "name": "Ireland and Northern Ireland",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/ireland-and-northern-ireland",
-          "subregions": []
+          "subregions": [],
+          "iso": "IE"
         },
         {
           "name": "Isle of Man",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/isle-of-man",
-          "subregions": []
+          "subregions": [],
+          "iso": "IM"
         },
         {
           "name": "Italy",
@@ -1177,7 +1352,8 @@
               "name": "Nord-Est",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/italy/nord-est",
-              "subregions": []
+              "subregions": [],
+              "iso": "HT-NE"
             },
             {
               "name": "Nord-Ovest",
@@ -1189,39 +1365,46 @@
               "name": "Sud",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/italy/sud",
-              "subregions": []
+              "subregions": [],
+              "iso": "RW-05"
             }
-          ]
+          ],
+          "iso": "IT"
         },
         {
           "name": "Kosovo",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/kosovo",
-          "subregions": []
+          "subregions": [],
+          "iso": "XK"
         },
         {
           "name": "Latvia",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/latvia",
-          "subregions": []
+          "subregions": [],
+          "iso": "LV"
         },
         {
           "name": "Liechtenstein",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/liechtenstein",
-          "subregions": []
+          "subregions": [],
+          "iso": "LI"
         },
         {
           "name": "Lithuania",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/lithuania",
-          "subregions": []
+          "subregions": [],
+          "iso": "LT"
         },
         {
           "name": "Luxembourg",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/luxembourg",
-          "subregions": []
+          "subregions": [],
+          "iso": "LU"
         },
         {
           "name": "Macedonia",
@@ -1233,25 +1416,29 @@
           "name": "Malta",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/malta",
-          "subregions": []
+          "subregions": [],
+          "iso": "MT"
         },
         {
           "name": "Moldova",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/moldova",
-          "subregions": []
+          "subregions": [],
+          "iso": "MD"
         },
         {
           "name": "Monaco",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/monaco",
-          "subregions": []
+          "subregions": [],
+          "iso": "MC"
         },
         {
           "name": "Montenegro",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/montenegro",
-          "subregions": []
+          "subregions": [],
+          "iso": "ME"
         },
         {
           "name": "Netherlands",
@@ -1262,81 +1449,95 @@
               "name": "Drenthe",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/netherlands/drenthe",
-              "subregions": []
+              "subregions": [],
+              "iso": "NL-DR"
             },
             {
               "name": "Flevoland",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/netherlands/flevoland",
-              "subregions": []
+              "subregions": [],
+              "iso": "NL-FL"
             },
             {
               "name": "Friesland",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/netherlands/friesland",
-              "subregions": []
+              "subregions": [],
+              "iso": "NL-FR"
             },
             {
               "name": "Gelderland",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/netherlands/gelderland",
-              "subregions": []
+              "subregions": [],
+              "iso": "NL-GE"
             },
             {
               "name": "Groningen",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/netherlands/groningen",
-              "subregions": []
+              "subregions": [],
+              "iso": "NL-GR"
             },
             {
               "name": "Limburg",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/netherlands/limburg",
-              "subregions": []
+              "subregions": [],
+              "iso": "NL-LI"
             },
             {
               "name": "Noord-Brabant",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/netherlands/noord-brabant",
-              "subregions": []
+              "subregions": [],
+              "iso": "NL-NB"
             },
             {
               "name": "Noord-Holland",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/netherlands/noord-holland",
-              "subregions": []
+              "subregions": [],
+              "iso": "NL-NH"
             },
             {
               "name": "Overijssel",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/netherlands/overijssel",
-              "subregions": []
+              "subregions": [],
+              "iso": "NL-OV"
             },
             {
               "name": "Zeeland",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/netherlands/zeeland",
-              "subregions": []
+              "subregions": [],
+              "iso": "NL-ZE"
             },
             {
               "name": "Zuid-Holland",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/netherlands/zuid-holland",
-              "subregions": []
+              "subregions": [],
+              "iso": "NL-ZH"
             },
             {
               "name": "Utrecht",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/netherlands/utrecht",
-              "subregions": []
+              "subregions": [],
+              "iso": "NL-UT"
             }
-          ]
+          ],
+          "iso": "NL"
         },
         {
           "name": "Norway",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/norway",
-          "subregions": []
+          "subregions": [],
+          "iso": "NO"
         },
         {
           "name": "Poland",
@@ -1347,159 +1548,186 @@
               "name": "Województwo dolnośląskie",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/poland/dolnoslaskie",
-              "subregions": []
+              "subregions": [],
+              "iso": "PL-02"
             },
             {
               "name": "Województwo kujawsko-pomorskie",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/poland/kujawsko-pomorskie",
-              "subregions": []
+              "subregions": [],
+              "iso": "PL-04"
             },
             {
               "name": "Województwo łódzkie",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/poland/lodzkie",
-              "subregions": []
+              "subregions": [],
+              "iso": "PL-10"
             },
             {
               "name": "Województwo lubelskie",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/poland/lubelskie",
-              "subregions": []
+              "subregions": [],
+              "iso": "PL-06"
             },
             {
               "name": "Województwo lubuskie",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/poland/lubuskie",
-              "subregions": []
+              "subregions": [],
+              "iso": "PL-08"
             },
             {
               "name": "Województwo małopolskie",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/poland/malopolskie",
-              "subregions": []
+              "subregions": [],
+              "iso": "PL-12"
             },
             {
               "name": "Województwo mazowieckie",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/poland/mazowieckie",
-              "subregions": []
+              "subregions": [],
+              "iso": "PL-14"
             },
             {
               "name": "Województwo opolskie",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/poland/opolskie",
-              "subregions": []
+              "subregions": [],
+              "iso": "PL-16"
             },
             {
               "name": "Województwo podkarpackie",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/poland/podkarpackie",
-              "subregions": []
+              "subregions": [],
+              "iso": "PL-18"
             },
             {
               "name": "Województwo podlaskie",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/poland/podlaskie",
-              "subregions": []
+              "subregions": [],
+              "iso": "PL-20"
             },
             {
               "name": "Województwo pomorskie",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/poland/pomorskie",
-              "subregions": []
+              "subregions": [],
+              "iso": "PL-22"
             },
             {
               "name": "Województwo śląskie",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/poland/slaskie",
-              "subregions": []
+              "subregions": [],
+              "iso": "PL-24"
             },
             {
               "name": "Województwo świętokrzyskie",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/poland/swietokrzyskie",
-              "subregions": []
+              "subregions": [],
+              "iso": "PL-26"
             },
             {
               "name": "Województwo zachodniopomorskie",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/poland/zachodniopomorskie",
-              "subregions": []
+              "subregions": [],
+              "iso": "PL-32"
             },
             {
               "name": "Województwo warmińsko-mazurskie",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/poland/warminsko-mazurskie",
-              "subregions": []
+              "subregions": [],
+              "iso": "PL-28"
             },
             {
               "name": "Województwo wielkopolskie",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/poland/wielkopolskie",
-              "subregions": []
+              "subregions": [],
+              "iso": "PL-30"
             }
-          ]
+          ],
+          "iso": "PL"
         },
         {
           "name": "Portugal",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/portugal",
-          "subregions": []
+          "subregions": [],
+          "iso": "PT"
         },
         {
           "name": "Romania",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/romania",
-          "subregions": []
+          "subregions": [],
+          "iso": "RO"
         },
         {
           "name": "Serbia",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/serbia",
-          "subregions": []
+          "subregions": [],
+          "iso": "RS"
         },
         {
           "name": "Slovakia",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/slovakia",
-          "subregions": []
+          "subregions": [],
+          "iso": "SK"
         },
         {
           "name": "Slovenia",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/slovenia",
-          "subregions": []
+          "subregions": [],
+          "iso": "SI"
         },
         {
           "name": "Spain",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/spain",
-          "subregions": []
+          "subregions": [],
+          "iso": "ES"
         },
         {
           "name": "Sweden",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/sweden",
-          "subregions": []
+          "subregions": [],
+          "iso": "SE"
         },
         {
           "name": "Switzerland",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/switzerland",
-          "subregions": []
+          "subregions": [],
+          "iso": "CH"
         },
         {
           "name": "Turkey",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/turkey",
-          "subregions": []
+          "subregions": [],
+          "iso": "TR"
         },
         {
           "name": "Ukraine (with Crimea)",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/ukraine",
-          "subregions": []
+          "subregions": [],
+          "iso": "UA"
         }
       ]
     },
@@ -1517,93 +1745,109 @@
               "name": "Alberta",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/north-america/canada/alberta",
-              "subregions": []
+              "subregions": [],
+              "iso": "CA-AB"
             },
             {
               "name": "British Columbia",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/north-america/canada/british-columbia",
-              "subregions": []
+              "subregions": [],
+              "iso": "CA-BC"
             },
             {
               "name": "Manitoba",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/north-america/canada/manitoba",
-              "subregions": []
+              "subregions": [],
+              "iso": "CA-MB"
             },
             {
               "name": "New Brunswick",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/north-america/canada/new-brunswick",
-              "subregions": []
+              "subregions": [],
+              "iso": "CA-NB"
             },
             {
               "name": "Newfoundland and Labrador",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/north-america/canada/newfoundland-and-labrador",
-              "subregions": []
+              "subregions": [],
+              "iso": "CA-NL"
             },
             {
               "name": "Northwest Territories",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/north-america/canada/northwest-territories",
-              "subregions": []
+              "subregions": [],
+              "iso": "CA-NT"
             },
             {
               "name": "Nova Scotia",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/north-america/canada/nova-scotia",
-              "subregions": []
+              "subregions": [],
+              "iso": "CA-NS"
             },
             {
               "name": "Nunavut",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/north-america/canada/nunavut",
-              "subregions": []
+              "subregions": [],
+              "iso": "CA-NU"
             },
             {
               "name": "Ontario",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/north-america/canada/ontario",
-              "subregions": []
+              "subregions": [],
+              "iso": "CA-ON"
             },
             {
               "name": "Prince Edward Island",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/north-america/canada/prince-edward-island",
-              "subregions": []
+              "subregions": [],
+              "iso": "CA-PE"
             },
             {
               "name": "Quebec",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/north-america/canada/quebec",
-              "subregions": []
+              "subregions": [],
+              "iso": "CA-QC"
             },
             {
               "name": "Saskatchewan",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/north-america/canada/saskatchewan",
-              "subregions": []
+              "subregions": [],
+              "iso": "CA-SK"
             },
             {
               "name": "Yukon",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/north-america/canada/yukon",
-              "subregions": []
+              "subregions": [],
+              "iso": "CA-YT"
             }
-          ]
+          ],
+          "iso": "CA"
         },
         {
           "name": "Greenland",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/north-america/greenland",
-          "subregions": []
+          "subregions": [],
+          "iso": "GL"
         },
         {
           "name": "Mexico",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/north-america/mexico",
-          "subregions": []
+          "subregions": [],
+          "iso": "MX"
         },
         {
           "name": "US",
@@ -1619,73 +1863,85 @@
                   "name": "Illinois",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/illinois",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-IL"
                 },
                 {
                   "name": "Indiana",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/indiana",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-IN"
                 },
                 {
                   "name": "Iowa",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/iowa",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-IA"
                 },
                 {
                   "name": "Kansas",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/kansas",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-KS"
                 },
                 {
                   "name": "Michigan",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/michigan",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-MI"
                 },
                 {
                   "name": "Minnesota",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/minnesota",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-MN"
                 },
                 {
                   "name": "Missouri",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/missouri",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-MO"
                 },
                 {
                   "name": "Nebraska",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/nebraska",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-NE"
                 },
                 {
                   "name": "North Dakota",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/north-dakota",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-ND"
                 },
                 {
                   "name": "Ohio",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/ohio",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-OH"
                 },
                 {
                   "name": "South Dakota",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/south-dakota",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-SD"
                 },
                 {
                   "name": "Wisconsin",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/wisconsin",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-WI"
                 }
               ]
             },
@@ -1698,73 +1954,85 @@
                   "name": "Connecticut",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/connecticut",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-CT"
                 },
                 {
                   "name": "District of Columbia",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/district-of-columbia",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-DC"
                 },
                 {
                   "name": "Maine",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/maine",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-ME"
                 },
                 {
                   "name": "Massachusetts",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/massachusetts",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-MA"
                 },
                 {
                   "name": "New Hampshire",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/new-hampshire",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-NH"
                 },
                 {
                   "name": "New Jersey",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/new-jersey",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-NJ"
                 },
                 {
                   "name": "New York",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/new-york",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-NY"
                 },
                 {
                   "name": "Pennsylvania",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/pennsylvania",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-PA"
                 },
                 {
                   "name": "Puerto Rico",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/puerto-rico",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-PR"
                 },
                 {
                   "name": "Rhode Island",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/rhode-island",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-RI"
                 },
                 {
                   "name": "United States Virgin Islands",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/us-virgin-islands",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-VI"
                 },
                 {
                   "name": "Vermont",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/vermont",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-VT"
                 }
               ]
             },
@@ -1777,13 +2045,15 @@
                   "name": "Alaska",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/alaska",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-AK"
                 },
                 {
                   "name": "Hawaii",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/hawaii",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-HI"
                 }
               ]
             },
@@ -1796,97 +2066,113 @@
                   "name": "Alabama",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/alabama",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-AL"
                 },
                 {
                   "name": "Arkansas",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/arkansas",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-AR"
                 },
                 {
                   "name": "Delaware",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/delaware",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-DE"
                 },
                 {
                   "name": "Florida",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/florida",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "UY-FD"
                 },
                 {
                   "name": "Georgia",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/georgia",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-GA"
                 },
                 {
                   "name": "Kentucky",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/kentucky",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-KY"
                 },
                 {
                   "name": "Louisiana",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/louisiana",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-LA"
                 },
                 {
                   "name": "Maryland",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/maryland",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-MD"
                 },
                 {
                   "name": "Mississippi",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/mississippi",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-MS"
                 },
                 {
                   "name": "North Carolina",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/north-carolina",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-NC"
                 },
                 {
                   "name": "Oklahoma",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/oklahoma",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-OK"
                 },
                 {
                   "name": "South Carolina",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/south-carolina",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-SC"
                 },
                 {
                   "name": "Tennessee",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/tennessee",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-TN"
                 },
                 {
                   "name": "Texas",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/texas",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-TX"
                 },
                 {
                   "name": "West Virginia",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/west-virginia",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-WV"
                 },
                 {
                   "name": "Virginia",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/virginia",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-VA"
                 }
               ]
             },
@@ -1899,71 +2185,83 @@
                   "name": "Arizona",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/arizona",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-AZ"
                 },
                 {
                   "name": "California",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/california",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-CA"
                 },
                 {
                   "name": "Colorado",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/colorado",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-CO"
                 },
                 {
                   "name": "Idaho",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/idaho",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-ID"
                 },
                 {
                   "name": "Montana",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/montana",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-MT"
                 },
                 {
                   "name": "Nevada",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/nevada",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-NV"
                 },
                 {
                   "name": "New Mexico",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/new-mexico",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-NM"
                 },
                 {
                   "name": "Oregon",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/oregon",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-OR"
                 },
                 {
                   "name": "Utah",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/utah",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-UT"
                 },
                 {
                   "name": "Washington",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/washington",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-WA"
                 },
                 {
                   "name": "Wyoming",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/wyoming",
-                  "subregions": []
+                  "subregions": [],
+                  "iso": "US-WY"
                 }
               ]
             }
-          ]
+          ],
+          "iso": "US"
         }
       ]
     },
@@ -2026,7 +2324,8 @@
           "taginfo_url": "https://taginfo.geofabrik.de/russia/volga-fed-district",
           "subregions": []
         }
-      ]
+      ],
+      "iso": "RU"
     },
     {
       "name": "South America",
@@ -2037,13 +2336,15 @@
           "name": "Argentina",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/south-america/argentina",
-          "subregions": []
+          "subregions": [],
+          "iso": "AR"
         },
         {
           "name": "Bolivia",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/south-america/bolivia",
-          "subregions": []
+          "subregions": [],
+          "iso": "BO"
         },
         {
           "name": "Brazil",
@@ -2080,55 +2381,64 @@
               "taginfo_url": "https://taginfo.geofabrik.de/south-america/brazil/sul",
               "subregions": []
             }
-          ]
+          ],
+          "iso": "BR"
         },
         {
           "name": "Chile",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/south-america/chile",
-          "subregions": []
+          "subregions": [],
+          "iso": "CL"
         },
         {
           "name": "Colombia",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/south-america/colombia",
-          "subregions": []
+          "subregions": [],
+          "iso": "CO"
         },
         {
           "name": "Ecuador",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/south-america/ecuador",
-          "subregions": []
+          "subregions": [],
+          "iso": "EC"
         },
         {
           "name": "Paraguay",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/south-america/paraguay",
-          "subregions": []
+          "subregions": [],
+          "iso": "PY"
         },
         {
           "name": "Peru",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/south-america/peru",
-          "subregions": []
+          "subregions": [],
+          "iso": "PE"
         },
         {
           "name": "Suriname",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/south-america/suriname",
-          "subregions": []
+          "subregions": [],
+          "iso": "SR"
         },
         {
           "name": "Uruguay",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/south-america/uruguay",
-          "subregions": []
+          "subregions": [],
+          "iso": "UY"
         },
         {
           "name": "Venezuela",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/south-america/venezuela",
-          "subregions": []
+          "subregions": [],
+          "iso": "VE"
         }
       ]
     }

--- a/OSM_regions.json
+++ b/OSM_regions.json
@@ -1,0 +1,2136 @@
+{
+  "name": "Global",
+  "admin_level": 0,
+  "taginfo_url": "https://taginfo.openstreetmap.org",
+  "subregions": [
+    {
+      "name": "Africa",
+      "admin_level": 1,
+      "taginfo_url": "https://taginfo.geofabrik.de/africa",
+      "subregions": [
+        {
+          "name": "Algeria",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/algeria",
+          "subregions": []
+        },
+        {
+          "name": "Angola",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/angola",
+          "subregions": []
+        },
+        {
+          "name": "Benin",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/benin",
+          "subregions": []
+        },
+        {
+          "name": "Botswana",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/botswana",
+          "subregions": []
+        },
+        {
+          "name": "Burkina Faso",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/burkina-faso",
+          "subregions": []
+        },
+        {
+          "name": "Burundi",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/burundi",
+          "subregions": []
+        },
+        {
+          "name": "Cameroon",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/cameroon",
+          "subregions": []
+        },
+        {
+          "name": "Canary Islands",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/canary-islands",
+          "subregions": []
+        },
+        {
+          "name": "Cape Verde",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/cape-verde",
+          "subregions": []
+        },
+        {
+          "name": "Central African Republic",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/central-african-republic",
+          "subregions": []
+        },
+        {
+          "name": "Chad",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/chad",
+          "subregions": []
+        },
+        {
+          "name": "Comores",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/comores",
+          "subregions": []
+        },
+        {
+          "name": "Congo (Republic/Brazzaville)",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/congo-brazzaville",
+          "subregions": []
+        },
+        {
+          "name": "Congo (Democratic Republic/Kinshasa)",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/congo-democratic-republic",
+          "subregions": []
+        },
+        {
+          "name": "Djibouti",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/djibouti",
+          "subregions": []
+        },
+        {
+          "name": "Egypt",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/egypt",
+          "subregions": []
+        },
+        {
+          "name": "Equatorial Guinea",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/equatorial-guinea",
+          "subregions": []
+        },
+        {
+          "name": "Eritrea",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/eritrea",
+          "subregions": []
+        },
+        {
+          "name": "Ethiopia",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/ethiopia",
+          "subregions": []
+        },
+        {
+          "name": "Gabon",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/gabon",
+          "subregions": []
+        },
+        {
+          "name": "Ghana",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/ghana",
+          "subregions": []
+        },
+        {
+          "name": "Guinea",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/guinea",
+          "subregions": []
+        },
+        {
+          "name": "Guinea-Bissau",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/guinea-bissau",
+          "subregions": []
+        },
+        {
+          "name": "Ivory Coast",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/ivory-coast",
+          "subregions": []
+        },
+        {
+          "name": "Kenya",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/kenya",
+          "subregions": []
+        },
+        {
+          "name": "Lesotho",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/lesotho",
+          "subregions": []
+        },
+        {
+          "name": "Liberia",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/liberia",
+          "subregions": []
+        },
+        {
+          "name": "Libya",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/libya",
+          "subregions": []
+        },
+        {
+          "name": "Madagascar",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/madagascar",
+          "subregions": []
+        },
+        {
+          "name": "Malawi",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/malawi",
+          "subregions": []
+        },
+        {
+          "name": "Mali",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/mali",
+          "subregions": []
+        },
+        {
+          "name": "Mauritania",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/mauritania",
+          "subregions": []
+        },
+        {
+          "name": "Mauritius",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/mauritius",
+          "subregions": []
+        },
+        {
+          "name": "Morocco",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/morocco",
+          "subregions": []
+        },
+        {
+          "name": "Mozambique",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/mozambique",
+          "subregions": []
+        },
+        {
+          "name": "Namibia",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/namibia",
+          "subregions": []
+        },
+        {
+          "name": "Niger",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/niger",
+          "subregions": []
+        },
+        {
+          "name": "Nigeria",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/nigeria",
+          "subregions": []
+        },
+        {
+          "name": "Rwanda",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/rwanda",
+          "subregions": []
+        },
+        {
+          "name": "Saint Helena, Ascension, and Tristan da Cunha",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/saint-helena-ascension-and-tristan-da-cunha",
+          "subregions": []
+        },
+        {
+          "name": "Sao Tome and Principe",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/sao-tome-and-principe",
+          "subregions": []
+        },
+        {
+          "name": "Senegal and Gambia",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/senegal-and-gambia",
+          "subregions": []
+        },
+        {
+          "name": "Seychelles",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/seychelles",
+          "subregions": []
+        },
+        {
+          "name": "Sierra Leone",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/sierra-leone",
+          "subregions": []
+        },
+        {
+          "name": "Somalia",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/somalia",
+          "subregions": []
+        },
+        {
+          "name": "South Africa",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/south-africa",
+          "subregions": []
+        },
+        {
+          "name": "South Africa (includes Lesotho)",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/south-africa-and-lesotho",
+          "subregions": []
+        },
+        {
+          "name": "South Sudan",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/south-sudan",
+          "subregions": []
+        },
+        {
+          "name": "Sudan",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/sudan",
+          "subregions": []
+        },
+        {
+          "name": "Swaziland",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/swaziland",
+          "subregions": []
+        },
+        {
+          "name": "Zambia",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/zambia",
+          "subregions": []
+        },
+        {
+          "name": "Zimbabwe",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/zimbabwe",
+          "subregions": []
+        },
+        {
+          "name": "Tanzania",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/tanzania",
+          "subregions": []
+        },
+        {
+          "name": "Togo",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/togo",
+          "subregions": []
+        },
+        {
+          "name": "Tunisia",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/tunisia",
+          "subregions": []
+        },
+        {
+          "name": "Uganda",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/africa/uganda",
+          "subregions": []
+        }
+      ]
+    },
+    {
+      "name": "Antarctica",
+      "admin_level": 1,
+      "taginfo_url": "https://taginfo.geofabrik.de/antarctica",
+      "subregions": []
+    },
+    {
+      "name": "Asia",
+      "admin_level": 1,
+      "taginfo_url": "https://taginfo.geofabrik.de/asia",
+      "subregions": [
+        {
+          "name": "Afghanistan",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/asia/afghanistan",
+          "subregions": []
+        },
+        {
+          "name": "Armenia",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/asia/armenia",
+          "subregions": []
+        },
+        {
+          "name": "Azerbaijan",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/asia/azerbaijan",
+          "subregions": []
+        },
+        {
+          "name": "Bangladesh",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/asia/bangladesh",
+          "subregions": []
+        },
+        {
+          "name": "Bhutan",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/asia/bhutan",
+          "subregions": []
+        },
+        {
+          "name": "Cambodia",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/asia/cambodia",
+          "subregions": []
+        },
+        {
+          "name": "China",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/asia/china",
+          "subregions": []
+        },
+        {
+          "name": "GCC States",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/asia/gcc-states",
+          "subregions": []
+        },
+        {
+          "name": "India",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/asia/india",
+          "subregions": []
+        },
+        {
+          "name": "Indonesia",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/asia/indonesia",
+          "subregions": []
+        },
+        {
+          "name": "Iran",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/asia/iran",
+          "subregions": []
+        },
+        {
+          "name": "Iraq",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/asia/iraq",
+          "subregions": []
+        },
+        {
+          "name": "Israel and Palestine",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/asia/israel-and-palestine",
+          "subregions": []
+        },
+        {
+          "name": "Japan",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/asia/japan",
+          "subregions": [
+            {
+              "name": "Chūbu region",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/asia/japan/chubu",
+              "subregions": []
+            },
+            {
+              "name": "Chūgoku region",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/asia/japan/chugoku",
+              "subregions": []
+            },
+            {
+              "name": "Hokkaidō",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/asia/japan/hokkaido",
+              "subregions": []
+            },
+            {
+              "name": "Kansai region (a.k.a. Kinki region)",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/asia/japan/kansai",
+              "subregions": []
+            },
+            {
+              "name": "Kantō region",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/asia/japan/kanto",
+              "subregions": []
+            },
+            {
+              "name": "Kyūshū",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/asia/japan/kyushu",
+              "subregions": []
+            },
+            {
+              "name": "Shikoku",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/asia/japan/shikoku",
+              "subregions": []
+            },
+            {
+              "name": "Tōhoku region",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/asia/japan/tohoku",
+              "subregions": []
+            }
+          ]
+        },
+        {
+          "name": "Jordan",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/asia/jordan",
+          "subregions": []
+        },
+        {
+          "name": "Kazakhstan",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/asia/kazakhstan",
+          "subregions": []
+        },
+        {
+          "name": "Kyrgyzstan",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/asia/kyrgyzstan",
+          "subregions": []
+        },
+        {
+          "name": "Laos",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/asia/laos",
+          "subregions": []
+        },
+        {
+          "name": "Lebanon",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/asia/lebanon",
+          "subregions": []
+        },
+        {
+          "name": "Malaysia, Singapore, and Brunei",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/asia/malaysia-singapore-brunei",
+          "subregions": []
+        },
+        {
+          "name": "Maldives",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/asia/maldives",
+          "subregions": []
+        },
+        {
+          "name": "Mongolia",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/asia/mongolia",
+          "subregions": []
+        },
+        {
+          "name": "Myanmar (a.k.a. Burma)",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/asia/myanmar",
+          "subregions": []
+        },
+        {
+          "name": "Nepal",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/asia/nepal",
+          "subregions": []
+        },
+        {
+          "name": "North Korea",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/asia/north-korea",
+          "subregions": []
+        },
+        {
+          "name": "Pakistan",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/asia/pakistan",
+          "subregions": []
+        },
+        {
+          "name": "Philippines",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/asia/philippines",
+          "subregions": []
+        },
+        {
+          "name": "South Korea",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/asia/south-korea",
+          "subregions": []
+        },
+        {
+          "name": "Sri Lanka",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/asia/sri-lanka",
+          "subregions": []
+        },
+        {
+          "name": "Syria",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/asia/syria",
+          "subregions": []
+        },
+        {
+          "name": "Taiwan",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/asia/taiwan",
+          "subregions": []
+        },
+        {
+          "name": "Tajikistan",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/asia/tajikistan",
+          "subregions": []
+        },
+        {
+          "name": "Thailand",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/asia/thailand",
+          "subregions": []
+        },
+        {
+          "name": "Turkmenistan",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/asia/turkmenistan",
+          "subregions": []
+        },
+        {
+          "name": "Uzbekistan",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/asia/uzbekistan",
+          "subregions": []
+        },
+        {
+          "name": "Vietnam",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/asia/vietnam",
+          "subregions": []
+        },
+        {
+          "name": "Yemen",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/asia/yemen",
+          "subregions": []
+        }
+      ]
+    },
+    {
+      "name": "Australia and Oceania",
+      "admin_level": 1,
+      "taginfo_url": "https://taginfo.geofabrik.de/australia-oceania",
+      "subregions": [
+        {
+          "name": "Australia",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/australia-oceania/australia",
+          "subregions": []
+        },
+        {
+          "name": "Fiji",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/australia-oceania/fiji",
+          "subregions": []
+        },
+        {
+          "name": "New Caledonia",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/australia-oceania/new-caledonia",
+          "subregions": []
+        },
+        {
+          "name": "New Zealand",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/australia-oceania/new-zealand",
+          "subregions": []
+        },
+        {
+          "name": "Papua New Guinea",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/australia-oceania/papua-new-guinea",
+          "subregions": []
+        }
+      ]
+    },
+    {
+      "name": "Central America",
+      "admin_level": 1,
+      "taginfo_url": "https://taginfo.geofabrik.de/central-america",
+      "subregions": [
+        {
+          "name": "Bahamas",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/central-america/bahamas",
+          "subregions": []
+        },
+        {
+          "name": "Belize",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/central-america/belize",
+          "subregions": []
+        },
+        {
+          "name": "Cuba",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/central-america/cuba",
+          "subregions": []
+        },
+        {
+          "name": "Guatemala",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/central-america/guatemala",
+          "subregions": []
+        },
+        {
+          "name": "Haiti and Dominican Republic",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/central-america/haiti-and-domrep",
+          "subregions": []
+        },
+        {
+          "name": "Jamaica",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/central-america/jamaica",
+          "subregions": []
+        },
+        {
+          "name": "Nicaragua",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/central-america/nicaragua",
+          "subregions": []
+        }
+      ]
+    },
+    {
+      "name": "Europe",
+      "admin_level": 1,
+      "taginfo_url": "https://taginfo.geofabrik.de/europe",
+      "subregions": [
+        {
+          "name": "Albania",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/albania",
+          "subregions": []
+        },
+        {
+          "name": "Alps",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/alps",
+          "subregions": []
+        },
+        {
+          "name": "Andorra",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/andorra",
+          "subregions": []
+        },
+        {
+          "name": "Azores",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/azores",
+          "subregions": []
+        },
+        {
+          "name": "Austria",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/austria",
+          "subregions": []
+        },
+        {
+          "name": "Belarus",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/belarus",
+          "subregions": []
+        },
+        {
+          "name": "Belgium",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/belgium",
+          "subregions": []
+        },
+        {
+          "name": "Bosnia-Herzegovina",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/bosnia-herzegovina",
+          "subregions": []
+        },
+        {
+          "name": "Britain and Ireland",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/britain-and-ireland",
+          "subregions": []
+        },
+        {
+          "name": "Bulgaria",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/bulgaria",
+          "subregions": []
+        },
+        {
+          "name": "Croatia",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/croatia",
+          "subregions": []
+        },
+        {
+          "name": "Czech Republic",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/czech-republic",
+          "subregions": []
+        },
+        {
+          "name": "Cyprus",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/cyprus",
+          "subregions": []
+        },
+        {
+          "name": "Denmark",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/denmark",
+          "subregions": []
+        },
+        {
+          "name": "Estonia",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/estonia",
+          "subregions": []
+        },
+        {
+          "name": "Faroe Islands",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/faroe-islands",
+          "subregions": []
+        },
+        {
+          "name": "Finland",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/finland",
+          "subregions": []
+        },
+        {
+          "name": "France",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/france",
+          "subregions": [
+            {
+              "name": "Alsace",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/france/alsace",
+              "subregions": []
+            },
+            {
+              "name": "Aquitaine",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/france/aquitaine",
+              "subregions": []
+            },
+            {
+              "name": "Auvergne",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/france/auvergne",
+              "subregions": []
+            },
+            {
+              "name": "Basse-Normandie",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/france/basse-normandie",
+              "subregions": []
+            },
+            {
+              "name": "Bourgogne",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/france/bourgogne",
+              "subregions": []
+            },
+            {
+              "name": "Bretagne",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/france/bretagne",
+              "subregions": []
+            },
+            {
+              "name": "Centre",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/france/centre",
+              "subregions": []
+            },
+            {
+              "name": "Champagne Ardenne",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/france/champagne-ardenne",
+              "subregions": []
+            },
+            {
+              "name": "Corse",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/france/corse",
+              "subregions": []
+            },
+            {
+              "name": "Franche Comte",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/france/franche-comte",
+              "subregions": []
+            },
+            {
+              "name": "Guadeloupe",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/france/guadeloupe",
+              "subregions": []
+            },
+            {
+              "name": "Guyane",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/france/guyane",
+              "subregions": []
+            },
+            {
+              "name": "Haute-Normandie",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/france/haute-normandie",
+              "subregions": []
+            },
+            {
+              "name": "Ile-de-France",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/france/ile-de-france",
+              "subregions": []
+            },
+            {
+              "name": "Languedoc-Roussillon",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/france/languedoc-roussillon",
+              "subregions": []
+            },
+            {
+              "name": "Limousin",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/france/limousin",
+              "subregions": []
+            },
+            {
+              "name": "Lorraine",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/france/lorraine",
+              "subregions": []
+            },
+            {
+              "name": "Martinique",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/france/martinique",
+              "subregions": []
+            },
+            {
+              "name": "Mayotte",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/france/mayotte",
+              "subregions": []
+            },
+            {
+              "name": "Midi-Pyrenees",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/france/midi-pyrenees",
+              "subregions": []
+            },
+            {
+              "name": "Nord-Pas-de-Calais",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/france/nord-pas-de-calais",
+              "subregions": []
+            },
+            {
+              "name": "Pays de la Loire",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/france/pays-de-la-loire",
+              "subregions": []
+            },
+            {
+              "name": "Picardie",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/france/picardie",
+              "subregions": []
+            },
+            {
+              "name": "Poitou-Charentes",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/france/poitou-charentes",
+              "subregions": []
+            },
+            {
+              "name": "Provence Alpes-Cote-d'Azur",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/france/provence-alpes-cote-d-azur",
+              "subregions": []
+            },
+            {
+              "name": "Reunion",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/france/reunion",
+              "subregions": []
+            },
+            {
+              "name": "Rhone-Alpes",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/france/rhone-alpes",
+              "subregions": []
+            }
+          ]
+        },
+        {
+          "name": "Georgia (Eastern Europe)",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/georgia",
+          "subregions": []
+        },
+        {
+          "name": "Germany",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/germany",
+          "subregions": [
+            {
+              "name": "Baden-Württemberg",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/baden-wuerttemberg",
+              "subregions": []
+            },
+            {
+              "name": "Bayern",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/bayern",
+              "subregions": []
+            },
+            {
+              "name": "Berlin",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/berlin",
+              "subregions": []
+            },
+            {
+              "name": "Brandenburg (mit Berlin)",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/brandenburg",
+              "subregions": []
+            },
+            {
+              "name": "Bremen",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/bremen",
+              "subregions": []
+            },
+            {
+              "name": "Hamburg",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/hamburg",
+              "subregions": []
+            },
+            {
+              "name": "Hessen",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/hessen",
+              "subregions": []
+            },
+            {
+              "name": "Mecklenburg-Vorpommern",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/mecklenburg-vorpommern",
+              "subregions": []
+            },
+            {
+              "name": "Niedersachsen",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/niedersachsen",
+              "subregions": []
+            },
+            {
+              "name": "Nordrhein-Westfalen",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/nordrhein-westfalen",
+              "subregions": []
+            },
+            {
+              "name": "Rheinland-Pfalz",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/rheinland-pfalz",
+              "subregions": []
+            },
+            {
+              "name": "Saarland",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/saarland",
+              "subregions": []
+            },
+            {
+              "name": "Sachsen",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/sachsen",
+              "subregions": []
+            },
+            {
+              "name": "Sachsen-Anhalt",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/sachsen-anhalt",
+              "subregions": []
+            },
+            {
+              "name": "Schleswig-Holstein",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/schleswig-holstein",
+              "subregions": []
+            },
+            {
+              "name": "Thüringen",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/thueringen",
+              "subregions": []
+            }
+          ]
+        },
+        {
+          "name": "Great Britain",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain",
+          "subregions": [
+            {
+              "name": "England",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england",
+              "subregions": []
+            },
+            {
+              "name": "Scotland",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/scotland",
+              "subregions": []
+            },
+            {
+              "name": "Wales",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/wales",
+              "subregions": []
+            }
+          ]
+        },
+        {
+          "name": "Greece",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/greece",
+          "subregions": []
+        },
+        {
+          "name": "Hungary",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/hungary",
+          "subregions": []
+        },
+        {
+          "name": "Iceland",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/iceland",
+          "subregions": []
+        },
+        {
+          "name": "Ireland and Northern Ireland",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/ireland-and-northern-ireland",
+          "subregions": []
+        },
+        {
+          "name": "Isle of Man",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/isle-of-man",
+          "subregions": []
+        },
+        {
+          "name": "Italy",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/italy",
+          "subregions": [
+            {
+              "name": "Centro",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/italy/centro",
+              "subregions": []
+            },
+            {
+              "name": "Isole",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/italy/isole",
+              "subregions": []
+            },
+            {
+              "name": "Nord-Est",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/italy/nord-est",
+              "subregions": []
+            },
+            {
+              "name": "Nord-Ovest",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/italy/nord-ovest",
+              "subregions": []
+            },
+            {
+              "name": "Sud",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/italy/sud",
+              "subregions": []
+            }
+          ]
+        },
+        {
+          "name": "Kosovo",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/kosovo",
+          "subregions": []
+        },
+        {
+          "name": "Latvia",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/latvia",
+          "subregions": []
+        },
+        {
+          "name": "Liechtenstein",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/liechtenstein",
+          "subregions": []
+        },
+        {
+          "name": "Lithuania",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/lithuania",
+          "subregions": []
+        },
+        {
+          "name": "Luxembourg",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/luxembourg",
+          "subregions": []
+        },
+        {
+          "name": "Macedonia",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/macedonia",
+          "subregions": []
+        },
+        {
+          "name": "Malta",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/malta",
+          "subregions": []
+        },
+        {
+          "name": "Moldova",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/moldova",
+          "subregions": []
+        },
+        {
+          "name": "Monaco",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/monaco",
+          "subregions": []
+        },
+        {
+          "name": "Montenegro",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/montenegro",
+          "subregions": []
+        },
+        {
+          "name": "Netherlands",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/netherlands",
+          "subregions": [
+            {
+              "name": "Drenthe",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/netherlands/drenthe",
+              "subregions": []
+            },
+            {
+              "name": "Flevoland",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/netherlands/flevoland",
+              "subregions": []
+            },
+            {
+              "name": "Friesland",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/netherlands/friesland",
+              "subregions": []
+            },
+            {
+              "name": "Gelderland",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/netherlands/gelderland",
+              "subregions": []
+            },
+            {
+              "name": "Groningen",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/netherlands/groningen",
+              "subregions": []
+            },
+            {
+              "name": "Limburg",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/netherlands/limburg",
+              "subregions": []
+            },
+            {
+              "name": "Noord-Brabant",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/netherlands/noord-brabant",
+              "subregions": []
+            },
+            {
+              "name": "Noord-Holland",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/netherlands/noord-holland",
+              "subregions": []
+            },
+            {
+              "name": "Overijssel",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/netherlands/overijssel",
+              "subregions": []
+            },
+            {
+              "name": "Zeeland",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/netherlands/zeeland",
+              "subregions": []
+            },
+            {
+              "name": "Zuid-Holland",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/netherlands/zuid-holland",
+              "subregions": []
+            },
+            {
+              "name": "Utrecht",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/netherlands/utrecht",
+              "subregions": []
+            }
+          ]
+        },
+        {
+          "name": "Norway",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/norway",
+          "subregions": []
+        },
+        {
+          "name": "Poland",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/poland",
+          "subregions": [
+            {
+              "name": "Województwo dolnośląskie",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/poland/dolnoslaskie",
+              "subregions": []
+            },
+            {
+              "name": "Województwo kujawsko-pomorskie",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/poland/kujawsko-pomorskie",
+              "subregions": []
+            },
+            {
+              "name": "Województwo łódzkie",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/poland/lodzkie",
+              "subregions": []
+            },
+            {
+              "name": "Województwo lubelskie",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/poland/lubelskie",
+              "subregions": []
+            },
+            {
+              "name": "Województwo lubuskie",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/poland/lubuskie",
+              "subregions": []
+            },
+            {
+              "name": "Województwo małopolskie",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/poland/malopolskie",
+              "subregions": []
+            },
+            {
+              "name": "Województwo mazowieckie",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/poland/mazowieckie",
+              "subregions": []
+            },
+            {
+              "name": "Województwo opolskie",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/poland/opolskie",
+              "subregions": []
+            },
+            {
+              "name": "Województwo podkarpackie",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/poland/podkarpackie",
+              "subregions": []
+            },
+            {
+              "name": "Województwo podlaskie",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/poland/podlaskie",
+              "subregions": []
+            },
+            {
+              "name": "Województwo pomorskie",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/poland/pomorskie",
+              "subregions": []
+            },
+            {
+              "name": "Województwo śląskie",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/poland/slaskie",
+              "subregions": []
+            },
+            {
+              "name": "Województwo świętokrzyskie",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/poland/swietokrzyskie",
+              "subregions": []
+            },
+            {
+              "name": "Województwo zachodniopomorskie",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/poland/zachodniopomorskie",
+              "subregions": []
+            },
+            {
+              "name": "Województwo warmińsko-mazurskie",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/poland/warminsko-mazurskie",
+              "subregions": []
+            },
+            {
+              "name": "Województwo wielkopolskie",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/europe/poland/wielkopolskie",
+              "subregions": []
+            }
+          ]
+        },
+        {
+          "name": "Portugal",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/portugal",
+          "subregions": []
+        },
+        {
+          "name": "Romania",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/romania",
+          "subregions": []
+        },
+        {
+          "name": "Serbia",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/serbia",
+          "subregions": []
+        },
+        {
+          "name": "Slovakia",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/slovakia",
+          "subregions": []
+        },
+        {
+          "name": "Slovenia",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/slovenia",
+          "subregions": []
+        },
+        {
+          "name": "Spain",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/spain",
+          "subregions": []
+        },
+        {
+          "name": "Sweden",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/sweden",
+          "subregions": []
+        },
+        {
+          "name": "Switzerland",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/switzerland",
+          "subregions": []
+        },
+        {
+          "name": "Turkey",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/turkey",
+          "subregions": []
+        },
+        {
+          "name": "Ukraine (with Crimea)",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/europe/ukraine",
+          "subregions": []
+        }
+      ]
+    },
+    {
+      "name": "North America",
+      "admin_level": 1,
+      "taginfo_url": "https://taginfo.geofabrik.de/north-america",
+      "subregions": [
+        {
+          "name": "Canada",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/north-america/canada",
+          "subregions": [
+            {
+              "name": "Alberta",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/north-america/canada/alberta",
+              "subregions": []
+            },
+            {
+              "name": "British Columbia",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/north-america/canada/british-columbia",
+              "subregions": []
+            },
+            {
+              "name": "Manitoba",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/north-america/canada/manitoba",
+              "subregions": []
+            },
+            {
+              "name": "New Brunswick",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/north-america/canada/new-brunswick",
+              "subregions": []
+            },
+            {
+              "name": "Newfoundland and Labrador",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/north-america/canada/newfoundland-and-labrador",
+              "subregions": []
+            },
+            {
+              "name": "Northwest Territories",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/north-america/canada/northwest-territories",
+              "subregions": []
+            },
+            {
+              "name": "Nova Scotia",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/north-america/canada/nova-scotia",
+              "subregions": []
+            },
+            {
+              "name": "Nunavut",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/north-america/canada/nunavut",
+              "subregions": []
+            },
+            {
+              "name": "Ontario",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/north-america/canada/ontario",
+              "subregions": []
+            },
+            {
+              "name": "Prince Edward Island",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/north-america/canada/prince-edward-island",
+              "subregions": []
+            },
+            {
+              "name": "Quebec",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/north-america/canada/quebec",
+              "subregions": []
+            },
+            {
+              "name": "Saskatchewan",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/north-america/canada/saskatchewan",
+              "subregions": []
+            },
+            {
+              "name": "Yukon",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/north-america/canada/yukon",
+              "subregions": []
+            }
+          ]
+        },
+        {
+          "name": "Greenland",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/north-america/greenland",
+          "subregions": []
+        },
+        {
+          "name": "Mexico",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/north-america/mexico",
+          "subregions": []
+        },
+        {
+          "name": "US",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/north-america/us",
+          "subregions": [
+            {
+              "name": "US Midwest",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/north-america/us-midwest",
+              "subregions": [
+                {
+                  "name": "Illinois",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/illinois",
+                  "subregions": []
+                },
+                {
+                  "name": "Indiana",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/indiana",
+                  "subregions": []
+                },
+                {
+                  "name": "Iowa",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/iowa",
+                  "subregions": []
+                },
+                {
+                  "name": "Kansas",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/kansas",
+                  "subregions": []
+                },
+                {
+                  "name": "Michigan",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/michigan",
+                  "subregions": []
+                },
+                {
+                  "name": "Minnesota",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/minnesota",
+                  "subregions": []
+                },
+                {
+                  "name": "Missouri",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/missouri",
+                  "subregions": []
+                },
+                {
+                  "name": "Nebraska",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/nebraska",
+                  "subregions": []
+                },
+                {
+                  "name": "North Dakota",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/north-dakota",
+                  "subregions": []
+                },
+                {
+                  "name": "Ohio",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/ohio",
+                  "subregions": []
+                },
+                {
+                  "name": "South Dakota",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/south-dakota",
+                  "subregions": []
+                },
+                {
+                  "name": "Wisconsin",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/wisconsin",
+                  "subregions": []
+                }
+              ]
+            },
+            {
+              "name": "US Northeast",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/north-america/us-northeast",
+              "subregions": [
+                {
+                  "name": "Connecticut",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/connecticut",
+                  "subregions": []
+                },
+                {
+                  "name": "District of Columbia",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/district-of-columbia",
+                  "subregions": []
+                },
+                {
+                  "name": "Maine",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/maine",
+                  "subregions": []
+                },
+                {
+                  "name": "Massachusetts",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/massachusetts",
+                  "subregions": []
+                },
+                {
+                  "name": "New Hampshire",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/new-hampshire",
+                  "subregions": []
+                },
+                {
+                  "name": "New Jersey",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/new-jersey",
+                  "subregions": []
+                },
+                {
+                  "name": "New York",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/new-york",
+                  "subregions": []
+                },
+                {
+                  "name": "Pennsylvania",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/pennsylvania",
+                  "subregions": []
+                },
+                {
+                  "name": "Puerto Rico",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/puerto-rico",
+                  "subregions": []
+                },
+                {
+                  "name": "Rhode Island",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/rhode-island",
+                  "subregions": []
+                },
+                {
+                  "name": "United States Virgin Islands",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/us-virgin-islands",
+                  "subregions": []
+                },
+                {
+                  "name": "Vermont",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/vermont",
+                  "subregions": []
+                }
+              ]
+            },
+            {
+              "name": "US Pacific",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/north-america/us-pacific",
+              "subregions": [
+                {
+                  "name": "Alaska",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/alaska",
+                  "subregions": []
+                },
+                {
+                  "name": "Hawaii",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/hawaii",
+                  "subregions": []
+                }
+              ]
+            },
+            {
+              "name": "US South",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/north-america/us-south",
+              "subregions": [
+                {
+                  "name": "Alabama",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/alabama",
+                  "subregions": []
+                },
+                {
+                  "name": "Arkansas",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/arkansas",
+                  "subregions": []
+                },
+                {
+                  "name": "Delaware",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/delaware",
+                  "subregions": []
+                },
+                {
+                  "name": "Florida",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/florida",
+                  "subregions": []
+                },
+                {
+                  "name": "Georgia",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/georgia",
+                  "subregions": []
+                },
+                {
+                  "name": "Kentucky",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/kentucky",
+                  "subregions": []
+                },
+                {
+                  "name": "Louisiana",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/louisiana",
+                  "subregions": []
+                },
+                {
+                  "name": "Maryland",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/maryland",
+                  "subregions": []
+                },
+                {
+                  "name": "Mississippi",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/mississippi",
+                  "subregions": []
+                },
+                {
+                  "name": "North Carolina",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/north-carolina",
+                  "subregions": []
+                },
+                {
+                  "name": "Oklahoma",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/oklahoma",
+                  "subregions": []
+                },
+                {
+                  "name": "South Carolina",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/south-carolina",
+                  "subregions": []
+                },
+                {
+                  "name": "Tennessee",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/tennessee",
+                  "subregions": []
+                },
+                {
+                  "name": "Texas",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/texas",
+                  "subregions": []
+                },
+                {
+                  "name": "West Virginia",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/west-virginia",
+                  "subregions": []
+                },
+                {
+                  "name": "Virginia",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/virginia",
+                  "subregions": []
+                }
+              ]
+            },
+            {
+              "name": "US West",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/north-america/us-west",
+              "subregions": [
+                {
+                  "name": "Arizona",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/arizona",
+                  "subregions": []
+                },
+                {
+                  "name": "California",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/california",
+                  "subregions": []
+                },
+                {
+                  "name": "Colorado",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/colorado",
+                  "subregions": []
+                },
+                {
+                  "name": "Idaho",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/idaho",
+                  "subregions": []
+                },
+                {
+                  "name": "Montana",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/montana",
+                  "subregions": []
+                },
+                {
+                  "name": "Nevada",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/nevada",
+                  "subregions": []
+                },
+                {
+                  "name": "New Mexico",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/new-mexico",
+                  "subregions": []
+                },
+                {
+                  "name": "Oregon",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/oregon",
+                  "subregions": []
+                },
+                {
+                  "name": "Utah",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/utah",
+                  "subregions": []
+                },
+                {
+                  "name": "Washington",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/washington",
+                  "subregions": []
+                },
+                {
+                  "name": "Wyoming",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/wyoming",
+                  "subregions": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Russia",
+      "admin_level": 1,
+      "taginfo_url": "https://taginfo.geofabrik.de/russia",
+      "subregions": [
+        {
+          "name": "Central Federal District",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/russia/central-fed-district",
+          "subregions": []
+        },
+        {
+          "name": "Crimean Federal District",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/russia/crimean-fed-district",
+          "subregions": []
+        },
+        {
+          "name": "Far Eastern Federal District",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/russia/far-eastern-fed-district",
+          "subregions": []
+        },
+        {
+          "name": "North Caucasus Federal District",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/russia/north-caucasus-fed-district",
+          "subregions": []
+        },
+        {
+          "name": "Northwestern Federal District",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/russia/northwestern-fed-district",
+          "subregions": []
+        },
+        {
+          "name": "Siberian Federal District",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/russia/siberian-fed-district",
+          "subregions": []
+        },
+        {
+          "name": "South Federal District",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/russia/south-fed-district",
+          "subregions": []
+        },
+        {
+          "name": "Ural Federal District",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/russia/ural-fed-district",
+          "subregions": []
+        },
+        {
+          "name": "Volga Federal District",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/russia/volga-fed-district",
+          "subregions": []
+        }
+      ]
+    },
+    {
+      "name": "South America",
+      "admin_level": 1,
+      "taginfo_url": "https://taginfo.geofabrik.de/south-america",
+      "subregions": [
+        {
+          "name": "Argnetina",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/south-america/argentina",
+          "subregions": []
+        },
+        {
+          "name": "Bolivia",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/south-america/bolivia",
+          "subregions": []
+        },
+        {
+          "name": "Brazil",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/south-america/brazil",
+          "subregions": [
+            {
+              "name": "Região Centro-Oeste",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/south-america/brazil/centro-oeste",
+              "subregions": []
+            },
+            {
+              "name": "Região Nordeste",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/south-america/brazil/nordeste",
+              "subregions": []
+            },
+            {
+              "name": "Região Norte",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/south-america/brazil/norte",
+              "subregions": []
+            },
+            {
+              "name": "Região Sudeste",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/south-america/brazil/sudeste",
+              "subregions": []
+            },
+            {
+              "name": "Região Sul",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/south-america/brazil/sul",
+              "subregions": []
+            }
+          ]
+        },
+        {
+          "name": "Chile",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/south-america/chile",
+          "subregions": []
+        },
+        {
+          "name": "Colombia",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/south-america/colombia",
+          "subregions": []
+        },
+        {
+          "name": "Ecuador",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/south-america/ecuador",
+          "subregions": []
+        },
+        {
+          "name": "Paraguay",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/south-america/paraguay",
+          "subregions": []
+        },
+        {
+          "name": "Peru",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/south-america/peru",
+          "subregions": []
+        },
+        {
+          "name": "Suriname",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/south-america/suriname",
+          "subregions": []
+        },
+        {
+          "name": "Uruguay",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/south-america/uruguay",
+          "subregions": []
+        },
+        {
+          "name": "Venezuela",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/south-america/venezuela",
+          "subregions": []
+        }
+      ]
+    }
+  ]
+}

--- a/OSM_regions.json
+++ b/OSM_regions.json
@@ -2034,7 +2034,7 @@
       "taginfo_url": "https://taginfo.geofabrik.de/south-america",
       "subregions": [
         {
-          "name": "Argnetina",
+          "name": "Argentina",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/south-america/argentina",
           "subregions": []

--- a/OSM_regions.json
+++ b/OSM_regions.json
@@ -418,13 +418,6 @@
           "iso": "AF"
         },
         {
-          "name": "East Timor",
-          "admin_level": 2,
-          "taginfo_url": "https://taginfo.geofabrik.de/asia/east-timor",
-          "subregions": [],
-          "iso": "TL"
-        },
-        {
           "name": "Armenia",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/asia/armenia",
@@ -2005,10 +1998,11 @@
           "iso": "LU"
         },
         {
-          "name": "Macedonia",
+          "name": "North Macedonia",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/europe/macedonia",
-          "subregions": []
+          "subregions": [],
+          "iso": "MK"
         },
         {
           "name": "Malta",

--- a/OSM_regions.json
+++ b/OSM_regions.json
@@ -418,6 +418,13 @@
           "iso": "AF"
         },
         {
+          "name": "East Timor",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/asia/east-timor",
+          "subregions": [],
+          "iso": "TL"
+        },
+        {
           "name": "Armenia",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/asia/armenia",
@@ -469,14 +476,101 @@
           "name": "India",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/asia/india",
-          "subregions": [],
+          "subregions": [
+            {
+              "name": "Central Zone",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/asia/india/central-zone",
+              "subregions": []
+            },
+            {
+              "name": "Eastern Zone",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/asia/india/eastern-zone",
+              "subregions": []
+            },
+            {
+              "name": "North-Eastern Zone",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/asia/india/north-eastern-zone",
+              "subregions": []
+            },
+            {
+              "name": "Northern Zone",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/asia/india/northern-zone",
+              "subregions": []
+            },
+            {
+              "name": "Southern Zone",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/asia/india/southern-zone",
+              "subregions": []
+            },
+            {
+              "name": "Western Zone",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/asia/india/western-zone",
+              "subregions": []
+            }
+          ],
           "iso": "IN"
         },
         {
           "name": "Indonesia",
           "admin_level": 2,
           "taginfo_url": "https://taginfo.geofabrik.de/asia/indonesia",
-          "subregions": [],
+          "subregions": [
+            {
+              "name": "Java",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/asia/indonesia/java",
+              "subregions": [],
+              "iso": "ID-JW"
+            },
+            {
+              "name": "Kalimantan",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/asia/indonesia/kalimantan",
+              "subregions": [],
+              "iso": "ID-KA"
+            },
+            {
+              "name": "Maluku",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/asia/indonesia/maluku",
+              "subregions": [],
+              "iso": "ID-ML"
+            },
+            {
+              "name": "Nusa-Tenggara",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/asia/indonesia/nusa-tenggara",
+              "subregions": [],
+              "iso": "ID-NU"
+            },
+            {
+              "name": "Papua",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/asia/indonesia/papua",
+              "subregions": [],
+              "iso": "ID-PP"
+            },
+            {
+              "name": "Sulawesi",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/asia/indonesia/sulawesi",
+              "subregions": [],
+              "iso": "ID-SL"
+            },
+            {
+              "name": "Sumatra",
+              "admin_level": 3,
+              "taginfo_url": "https://taginfo.geofabrik.de/asia/indonesia/sumatra",
+              "subregions": [],
+              "iso": "ID-SM"
+            }
+          ],
           "iso": "ID"
         },
         {
@@ -750,6 +844,90 @@
           "taginfo_url": "https://taginfo.geofabrik.de/australia-oceania/new-zealand",
           "subregions": [],
           "iso": "NZ"
+        },
+        {
+          "name": "Cook Islands",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/australia-oceania/cook-islands",
+          "subregions": [],
+          "iso": "CK"
+        },
+        {
+          "name": "Kiribati",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/australia-oceania/kiribati",
+          "subregions": [],
+          "iso": "KI"
+        },
+        {
+          "name": "Marshall Islands",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/australia-oceania/marshall-islands",
+          "subregions": [],
+          "iso": "MH"
+        },
+        {
+          "name": "Micronesia",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/australia-oceania/micronesia",
+          "subregions": [],
+          "iso": "FM"
+        },
+        {
+          "name": "Nauru",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/australia-oceania/nauru",
+          "subregions": [],
+          "iso": "NR"
+        },
+        {
+          "name": "Niue",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/australia-oceania/niue",
+          "subregions": [],
+          "iso": "NU"
+        },
+        {
+          "name": "Palau",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/australia-oceania/palau",
+          "subregions": [],
+          "iso": "PW"
+        },
+        {
+          "name": "Samoa",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/australia-oceania/samoa",
+          "subregions": [],
+          "iso": "WS"
+        },
+        {
+          "name": "Solomon Islands",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/australia-oceania/solomon-islands",
+          "subregions": [],
+          "iso": "SB"
+        },
+        {
+          "name": "Tonga",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/australia-oceania/tonga",
+          "subregions": [],
+          "iso": "TO"
+        },
+        {
+          "name": "Tuvalu",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/australia-oceania/tuvalu",
+          "subregions": [],
+          "iso": "TV"
+        },
+        {
+          "name": "Vanuatu",
+          "admin_level": 2,
+          "taginfo_url": "https://taginfo.geofabrik.de/australia-oceania/vanuatu",
+          "subregions": [],
+          "iso": "VU"
         },
         {
           "name": "Papua New Guinea",
@@ -1156,14 +1334,82 @@
               "name": "Baden-Württemberg",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/baden-wuerttemberg",
-              "subregions": [],
+              "subregions": [
+                {
+                  "name": "Regierungsbezirk Freiburg",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/baden-wuerttemberg/freiburg-regbez",
+                  "subregions": []
+                },
+                {
+                  "name": "Regierungsbezirk Karlsruhe",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/baden-wuerttemberg/karlsruhe-regbez",
+                  "subregions": []
+                },
+                {
+                  "name": "Regierungsbezirk Stuttgart",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/baden-wuerttemberg/stuttgart-regbez",
+                  "subregions": []
+                },
+                {
+                  "name": "Regierungsbezirk Tübingen",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/baden-wuerttemberg/tuebingen-regbez",
+                  "subregions": []
+                }
+              ],
               "iso": "DE-BW"
             },
             {
               "name": "Bayern",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/bayern",
-              "subregions": [],
+              "subregions": [
+                {
+                  "name": "Mittelfranken",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/bayern/mittelfranken",
+                  "subregions": []
+                },
+                {
+                  "name": "Niederbayern",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/bayern/niederbayern",
+                  "subregions": []
+                },
+                {
+                  "name": "Oberbayern",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/bayern/oberbayern",
+                  "subregions": []
+                },
+                {
+                  "name": "Oberfranken",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/bayern/oberfranken",
+                  "subregions": []
+                },
+                {
+                  "name": "Oberpfalz",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/bayern/oberpfalz",
+                  "subregions": []
+                },
+                {
+                  "name": "Schwaben",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/bayern/schwaben",
+                  "subregions": []
+                },
+                {
+                  "name": "Unterfranken",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/bayern/unterfranken",
+                  "subregions": []
+                }
+              ],
               "iso": "DE-BY"
             },
             {
@@ -1219,7 +1465,38 @@
               "name": "Nordrhein-Westfalen",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/nordrhein-westfalen",
-              "subregions": [],
+              "subregions": [
+                {
+                  "name": "Regierungsbezirk Arnsberg",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/nordrhein-westfalen/arnsberg-regbez",
+                  "subregions": []
+                },
+                {
+                  "name": "Regierungsbezirk Detmold",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/nordrhein-westfalen/detmold-regbez",
+                  "subregions": []
+                },
+                {
+                  "name": "Regierungsbezirk Düsseldorf",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/nordrhein-westfalen/duesseldorf-regbez",
+                  "subregions": []
+                },
+                {
+                  "name": "Regierungsbezirk Köln",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/nordrhein-westfalen/koeln-regbez",
+                  "subregions": []
+                },
+                {
+                  "name": "Regierungsbezirk Münster",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/germany/nordrhein-westfalen/muenster-regbez",
+                  "subregions": []
+                }
+              ],
               "iso": "DE-NW"
             },
             {
@@ -1276,7 +1553,328 @@
               "name": "England",
               "admin_level": 3,
               "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england",
-              "subregions": [],
+              "subregions": [
+                {
+                  "name": "Bedfordshire",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/bedfordshire",
+                  "subregions": []
+                },
+                {
+                  "name": "Berkshire",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/berkshire",
+                  "subregions": []
+                },
+                {
+                  "name": "Bristol",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/bristol",
+                  "subregions": [],
+                  "iso": "GB-BST"
+                },
+                {
+                  "name": "Buckinghamshire",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/buckinghamshire",
+                  "subregions": [],
+                  "iso": "GB-BKM"
+                },
+                {
+                  "name": "Cambridgeshire",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/cambridgeshire",
+                  "subregions": [],
+                  "iso": "GB-CAM"
+                },
+                {
+                  "name": "Cheshire",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/cheshire",
+                  "subregions": []
+                },
+                {
+                  "name": "Cornwall",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/cornwall",
+                  "subregions": [],
+                  "iso": "GB-CON"
+                },
+                {
+                  "name": "Cumbria",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/cumbria",
+                  "subregions": [],
+                  "iso": "GB-CMA"
+                },
+                {
+                  "name": "Derbyshire",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/derbyshire",
+                  "subregions": [],
+                  "iso": "GB-DBY"
+                },
+                {
+                  "name": "Devon",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/devon",
+                  "subregions": [],
+                  "iso": "GB-DEV"
+                },
+                {
+                  "name": "Dorset",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/dorset",
+                  "subregions": [],
+                  "iso": "GB-DOR"
+                },
+                {
+                  "name": "Durham",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/durham",
+                  "subregions": [],
+                  "iso": "GB-DUR"
+                },
+                {
+                  "name": "East Sussex",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/east-sussex",
+                  "subregions": [],
+                  "iso": "GB-ESX"
+                },
+                {
+                  "name": "East Yorkshire with Hull",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/east-yorkshire-with-hull",
+                  "subregions": [],
+                  "iso": "GB-ERY"
+                },
+                {
+                  "name": "Essex",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/essex",
+                  "subregions": [],
+                  "iso": "GB-ESS"
+                },
+                {
+                  "name": "Gloucestershire",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/gloucestershire",
+                  "subregions": [],
+                  "iso": "GB-GLS"
+                },
+                {
+                  "name": "Greater London",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/greater-london",
+                  "subregions": []
+                },
+                {
+                  "name": "Greater Manchester",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/greater-manchester",
+                  "subregions": []
+                },
+                {
+                  "name": "Hampshire",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/hampshire",
+                  "subregions": [],
+                  "iso": "GB-HAM"
+                },
+                {
+                  "name": "Herefordshire",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/herefordshire",
+                  "subregions": [],
+                  "iso": "GB-HEF"
+                },
+                {
+                  "name": "Hertfordshire",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/hertfordshire",
+                  "subregions": [],
+                  "iso": "GB-HRT"
+                },
+                {
+                  "name": "Isle of Wight",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/isle-of-wight",
+                  "subregions": [],
+                  "iso": "GB-IOW"
+                },
+                {
+                  "name": "Kent",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/kent",
+                  "subregions": [],
+                  "iso": "GB-KEN"
+                },
+                {
+                  "name": "Lancashire",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/lancashire",
+                  "subregions": [],
+                  "iso": "GB-LAN"
+                },
+                {
+                  "name": "Leicestershire",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/leicestershire",
+                  "subregions": [],
+                  "iso": "GB-LEC"
+                },
+                {
+                  "name": "Lincolnshire",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/lincolnshire",
+                  "subregions": [],
+                  "iso": "GB-LIN"
+                },
+                {
+                  "name": "Merseyside",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/merseyside",
+                  "subregions": []
+                },
+                {
+                  "name": "Norfolk",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/norfolk",
+                  "subregions": [],
+                  "iso": "GB-NFK"
+                },
+                {
+                  "name": "Northamptonshire",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/northamptonshire",
+                  "subregions": [],
+                  "iso": "GB-NTH"
+                },
+                {
+                  "name": "Northumberland",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/northumberland",
+                  "subregions": [],
+                  "iso": "GB-NBL"
+                },
+                {
+                  "name": "North Yorkshire",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/north-yorkshire",
+                  "subregions": [],
+                  "iso": "GB-NYK"
+                },
+                {
+                  "name": "Nottinghamshire",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/nottinghamshire",
+                  "subregions": [],
+                  "iso": "GB-NTT"
+                },
+                {
+                  "name": "Oxfordshire",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/oxfordshire",
+                  "subregions": [],
+                  "iso": "GB-OXF"
+                },
+                {
+                  "name": "Rutland",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/rutland",
+                  "subregions": [],
+                  "iso": "GB-RUT"
+                },
+                {
+                  "name": "Shropshire",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/shropshire",
+                  "subregions": [],
+                  "iso": "GB-SHR"
+                },
+                {
+                  "name": "Somerset",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/somerset",
+                  "subregions": [],
+                  "iso": "GB-SOM"
+                },
+                {
+                  "name": "South Yorkshire",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/south-yorkshire",
+                  "subregions": []
+                },
+                {
+                  "name": "Staffordshire",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/staffordshire",
+                  "subregions": [],
+                  "iso": "GB-STS"
+                },
+                {
+                  "name": "Suffolk",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/suffolk",
+                  "subregions": [],
+                  "iso": "GB-SFK"
+                },
+                {
+                  "name": "Surrey",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/surrey",
+                  "subregions": [],
+                  "iso": "GB-SRY"
+                },
+                {
+                  "name": "Tyne and Wear",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/tyne-and-wear",
+                  "subregions": []
+                },
+                {
+                  "name": "Warwickshire",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/warwickshire",
+                  "subregions": [],
+                  "iso": "GB-WAR"
+                },
+                {
+                  "name": "West Midlands",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/west-midlands",
+                  "subregions": []
+                },
+                {
+                  "name": "West Sussex",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/west-sussex",
+                  "subregions": [],
+                  "iso": "GB-WSX"
+                },
+                {
+                  "name": "West Yorkshire",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/west-yorkshire",
+                  "subregions": [],
+                  "iso": ""
+                },
+                {
+                  "name": "Wiltshire",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/wiltshire",
+                  "subregions": [],
+                  "iso": "GB-WIL"
+                },
+                {
+                  "name": "Worcestershire",
+                  "admin_level": 4,
+                  "taginfo_url": "https://taginfo.geofabrik.de/europe/great-britain/england/worcestershire",
+                  "subregions": [],
+                  "iso": "GB-WOR"
+                }
+              ],
               "iso": "GB-ENG"
             },
             {
@@ -2021,13 +2619,6 @@
                   "iso": "US-RI"
                 },
                 {
-                  "name": "United States Virgin Islands",
-                  "admin_level": 4,
-                  "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/us-virgin-islands",
-                  "subregions": [],
-                  "iso": "US-VI"
-                },
-                {
                   "name": "Vermont",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/vermont",
@@ -2192,7 +2783,20 @@
                   "name": "California",
                   "admin_level": 4,
                   "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/california",
-                  "subregions": [],
+                  "subregions": [
+                    {
+                      "name": "Northern California",
+                      "admin_level": 5,
+                      "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/california/norcal",
+                      "subregions": []
+                    },
+                    {
+                      "name": "Southern California",
+                      "admin_level": 5,
+                      "taginfo_url": "https://taginfo.geofabrik.de/north-america/us/california/socal",
+                      "subregions": []
+                    }
+                  ],
                   "iso": "US-CA"
                 },
                 {

--- a/README.md
+++ b/README.md
@@ -88,3 +88,7 @@ For python:
      pip install matplotlib
      pip install geopandas
 
+## Taginfo version
+Usually you don't need newest country tag statistics for latest minute, but you would satisfy also with day or two old information. For such purpose this repo features `taginfo_compare_tags` scripts, which will use taginfo pages to get precompiled tag counts faster than any overpass could offer. Two scripts rely heavily on [[OSM_regions.json]] datafile, which namely contains information on *(almost)* all the Geofabrik's taginfo servers in structured manner. List has been compiled automatically, but information for some subregions and additional information were added manually. 
+
+TODO: Add ISO codes to subregions. Support for subregions will need special treatment in R.

--- a/README.md
+++ b/README.md
@@ -91,4 +91,6 @@ For python:
 ## Taginfo version
 Usually you don't need newest country tag statistics for latest minute, but you would satisfy also with day or two old information. For such purpose this repo features `taginfo_compare_tags` scripts, which will use taginfo pages to get precompiled tag counts faster than any overpass could offer. Two scripts rely heavily on [[OSM_regions.json]] datafile, which namely contains information on *(almost)* all the Geofabrik's taginfo servers in structured manner. List has been compiled automatically, but information for some subregions and additional information were added manually. 
 
-TODO: Add ISO codes to subregions. Support for subregions will need special treatment in R.
+Using this version proceses ~150 countries in 30 seconds using taginfo, and remaining 45 in 12 minutes using overpass. Option to drop overpass is not implemented yet. Potential way to speed up overpass, is merge small countries into single overpass query.
+
+TODO: Add plotting support for subregions. Support for subregions will need special treatment in R.

--- a/countries_wo_taginfo.txt
+++ b/countries_wo_taginfo.txt
@@ -1,0 +1,45 @@
+36989,VA,Vatican City
+54624,SM,San Marino
+192774,GM,The Gambia
+192775,SN,Senegal
+270009,GG,Guernsey
+285454,VG,British Virgin Islands
+287083,GY,Guyana
+287667,CR,Costa Rica
+287668,PA,Panama
+287670,HN,Honduras
+305095,QA,Qatar
+305099,KW,Kuwait
+305138,OM,Oman
+307584,SA,Saudi Arabia
+307763,AE,United Arab Emirates
+307823,DM,Dominica
+307828,DO,Dominican Republic
+307829,HT,Haiti
+367988,JE,Jersey
+378734,BH,Bahrain
+535880,ST,São Tomé and Príncipe
+536780,SG,Singapore
+536899,KN,Saint Kitts and Nevis
+536900,AG,Antigua and Barbuda
+537257,MS,Montserrat
+547479,TC,Turks and Caicos Islands
+547511,BB,Barbados
+550725,VC,Saint Vincent and the Grenadines
+550727,GD,Grenada
+550728,LC,Saint Lucia
+555717,TT,Trinidad and Tobago
+1278736,GI,Gibraltar
+1473946,IL,Israel
+1520612,SV,El Salvador
+1964272,SH,"Saint Helena, Ascension and Tristan da Cunha"
+1983628,GS,South Georgia and the South Sandwich Islands
+1993208,BM,Bermuda
+1993867,IO,British Indian Ocean Territory
+2103120,BN,Brunei
+2108121,MY,Malaysia
+2177161,AI,Anguilla
+2185366,KY,Cayman Islands
+2185374,FK,Falkland Islands
+2185375,PN,Pitcairn Islands
+2186600,TK,Tokelau

--- a/plot_tagDensity.py
+++ b/plot_tagDensity.py
@@ -26,16 +26,16 @@ parser.add_argument('-i', '--input', type=str,
                     help='Input CSV file lat, lon coordinates')
 parser.add_argument('-o', '--output', type=str,
                     help='Outputfile for plot (.png, ,jpg, .pdf)',
-                    default = "plot_" + str(datetime.datetime.now()) + ".png")
+                    default="plot_" + str(datetime.datetime.now()) + ".png")
 parser.add_argument('-t', '--tag', type=str,
                     help='tag name',
-                    default = "tag density")
+                    default="tag density")
 parser.add_argument('-w', '--binwidth', type=float,
                     help='size of square for object counting in degrees',
-                    default = 1)
+                    default=1)
 parser.add_argument('-b', '--bbox', type=str,
                     help='four coordinates separeatd by comma',
-                    default = "-55,-180,90,180")
+                    default="-55,-180,90,180")
 parser.add_argument('-c', '--countries', type=str, choices=['yes', 'no'],
                     help='whether to plot borders (default: no)',
                     default='no')
@@ -46,7 +46,6 @@ bbox = args.bbox.split(",")
 bbox = [float(x) for x in bbox]
 
 
-  
 if args.input == '-':
     overpass = np.genfromtxt(sys.stdin, delimiter=',', skip_header=1)
 else:
@@ -66,22 +65,22 @@ lon_bins = np.linspace(-180, 180, nx+1)
 lat_bins = np.linspace(-90, 90, ny+1)
 
 # Calculate frequency in each square bin
-density, _, _ = np.histogram2d(overpass[:,0], overpass[:,1], [lat_bins, lon_bins])
+density, _, _ = np.histogram2d(overpass[:, 0], overpass[:, 1], [lat_bins, lon_bins])
 
 # Turn the lon/lat bins into 2 dimensional arrays
 lon_bins_2d, lat_bins_2d = np.meshgrid(lon_bins, lat_bins)
 
 
 fig, ax = plt.subplots()
-#ax.set_aspect('equal')
+# ax.set_aspect('equal')
 ax.set_facecolor('black')
 ax.axis([bbox[1], bbox[3], bbox[0], bbox[2]])
 ax.set_title(args.tag, fontsize=15)
 
 plt.pcolormesh(lon_bins_2d, lat_bins_2d, np.log10(density), cmap='plasma', zorder=1)
-world.boundary.plot(ax=ax, edgecolor='grey', linewidth = 0.25, zorder=2)
+world.boundary.plot(ax=ax, edgecolor='grey', linewidth=0.25, zorder=2)
 
-plt.colorbar(label = r'$log_{10}$', fraction = 0.04, aspect = 6)
+plt.colorbar(label=r'$log_{10}$', fraction=0.04, aspect=6)
 fig.text(.77, .22, str(date.today()), ha='center')
 
 plt.savefig(args.output, dpi = 300, bbox_inches='tight')

--- a/sample list of countries.txt
+++ b/sample list of countries.txt
@@ -1,0 +1,216 @@
+9407,AD,Andorra
+14296,SK,Slovakia
+16239,AT,Austria
+21335,HU,Hungary
+28699,GE,Georgia
+36989,VA,Vatican City
+49715,PL,Poland
+49898,KH,Cambodia
+49903,LA,Laos
+49915,VN,Vietnam
+50046,DK,Denmark
+50371,MM,Myanmar
+51477,DE,Germany
+51684,CZ,Czechia
+51701,CH,Switzerland
+52411,BE,Belgium
+52822,SE,Sweden
+52939,FO,Faroe Islands
+53292,AL,Albania
+53293,MK,North Macedonia
+53296,ME,Montenegro
+54224,FI,Finland
+54624,SM,San Marino
+58974,MD,Moldova
+59065,BY,Belarus
+59470,BR,Brazil
+60189,RU,Russia
+60199,UA,Ukraine
+62149,GB,United Kingdom
+62269,IM,Isle of Man
+62273,IE,Ireland
+72594,LV,Latvia
+72596,LT,Lithuania
+79510,EE,Estonia
+80500,AU,Australia
+87565,ZA,South Africa
+88210,SZ,Eswatini
+90689,RO,Romania
+108089,EC,Ecuador
+114686,MX,Mexico
+120027,CO,Colombia
+148838,US,United States
+161033,MN,Mongolia
+167454,CL,Chile
+171496,RW,Rwanda
+174737,TR,Turkey
+178009,KG,Kyrgyzstan
+184629,BT,Bhutan
+184633,NP,Nepal
+184640,BD,Bangladesh
+184818,JO,Jordan
+184840,SY,Syria
+184843,LB,Lebanon
+186382,BG,Bulgaria
+192307,GR,Greece
+192734,KP,North Korea
+192756,DZ,Algeria
+192757,TN,Tunisia
+192758,LY,Libya
+192763,MR,Mauritania
+192774,GM,The Gambia
+192775,SN,Senegal
+192776,GW,Guinea-Bissau
+192777,SL,Sierra Leone
+192778,GN,Guinea
+192779,CI,Côte d'Ivoire
+192780,LR,Liberia
+192781,GH,Ghana
+192782,TG,Togo
+192783,BF,Burkina Faso
+192784,BJ,Benin
+192785,ML,Mali
+192786,NE,Niger
+192787,NG,Nigeria
+192789,SD,Sudan
+192790,CF,Central African Republic
+192791,GQ,Equatorial Guinea
+192793,GA,Gabon
+192794,CG,Congo-Brazzaville
+192795,CD,Democratic Republic of the Congo
+192796,UG,Uganda
+192798,KE,Kenya
+192799,SO,Somalia
+192800,ET,Ethiopia
+192801,DJ,Djibouti
+192830,CM,Cameroon
+195266,NA,Namibia
+195267,AO,Angola
+195269,BI,Burundi
+195270,TZ,Tanzania
+195271,ZM,Zambia
+195272,ZW,Zimbabwe
+195273,MZ,Mozambique
+195290,MW,Malawi
+196240,UZ,Uzbekistan
+214626,TJ,Tajikistan
+214665,KZ,Kazakhstan
+214885,HR,Croatia
+218657,SI,Slovenia
+223026,TM,Turkmenistan
+252645,BO,Bolivia
+270009,GG,Guernsey
+270056,CN,China
+272644,VE,Venezuela
+285454,VG,British Virgin Islands
+286393,AR,Argentina
+287072,UY,Uruguay
+287077,PY,Paraguay
+287082,SR,Suriname
+287083,GY,Guyana
+287666,NI,Nicaragua
+287667,CR,Costa Rica
+287668,PA,Panama
+287670,HN,Honduras
+287827,BZ,Belize
+288247,PE,Peru
+295480,PT,Portugal
+296961,ER,Eritrea
+299133,IS,Iceland
+303427,AF,Afghanistan
+304716,IN,India
+304751,ID,Indonesia
+304934,IQ,Iraq
+304938,IR,Iran
+305092,YE,Yemen
+305095,QA,Qatar
+305099,KW,Kuwait
+305138,OM,Oman
+305142,TL,East Timor
+307573,PK,Pakistan
+307584,SA,Saudi Arabia
+307756,KR,South Korea
+307763,AE,United Arab Emirates
+307787,CY,Cyprus
+307823,DM,Dominica
+307828,DO,Dominican Republic
+307829,HT,Haiti
+307833,CU,Cuba
+307866,PG,Papua New Guinea
+364066,AM,Armenia
+364110,AZ,Azerbaijan
+365307,MT,Malta
+365331,IT,Italy
+367988,JE,Jersey
+378734,BH,Bahrain
+382313,JP,Japan
+443174,PH,Philippines
+447325,MG,Madagascar
+449220,TW,Taiwan
+535774,CV,Cape Verde
+535790,KM,Comoros
+535828,MU,Mauritius
+535880,ST,São Tomé and Príncipe
+536765,SC,Seychelles
+536773,MV,Maldives
+536780,SG,Singapore
+536807,LK,Sri Lanka
+536899,KN,Saint Kitts and Nevis
+536900,AG,Antigua and Barbuda
+537257,MS,Montserrat
+547469,BS,The Bahamas
+547479,TC,Turks and Caicos Islands
+547511,BB,Barbados
+550725,VC,Saint Vincent and the Grenadines
+550727,GD,Grenada
+550728,LC,Saint Lucia
+555017,JM,Jamaica
+555717,TT,Trinidad and Tobago
+556706,NZ,New Zealand
+571178,KI,Kiribati
+571747,FJ,Fiji
+571771,MH,Marshall Islands
+571802,FM,Federated States of Micronesia
+571804,NR,Nauru
+571805,PW,Palau
+1124039,MC,Monaco
+1155955,LI,Liechtenstein
+1278736,GI,Gibraltar
+1311341,ES,Spain
+1428125,CA,Canada
+1473946,IL,Israel
+1473947,EG,Egypt
+1520612,SV,El Salvador
+1521463,GT,Guatemala
+1558556,NU,Niue
+1656678,SS,South Sudan
+1741311,RS,Serbia
+1857436,SB,Solomon Islands
+1872673,WS,Samoa
+1889339,BW,Botswana
+1964272,SH,"Saint Helena, Ascension and Tristan da Cunha"
+1983628,GS,South Georgia and the South Sandwich Islands
+1993208,BM,Bermuda
+1993867,IO,British Indian Ocean Territory
+2067731,TH,Thailand
+2088990,XK,Kosovo
+2093234,LS,Lesotho
+2103120,BN,Brunei
+2108121,MY,Malaysia
+2171347,LU,Luxembourg
+2177161,AI,Anguilla
+2177246,VU,Vanuatu
+2177266,TV,Tuvalu
+2184073,GL,Greenland
+2184233,CK,Cook Islands
+2185366,KY,Cayman Islands
+2185374,FK,Falkland Islands
+2185375,PN,Pitcairn Islands
+2186600,TK,Tokelau
+2186665,TO,Tonga
+2202162,FR,France
+2323309,NL,Netherlands
+2361304,TD,Chad
+2528142,BA,Bosnia and Herzegovina
+2978650,NO,Norway
+3630439,MA,Morocco

--- a/taginfo_compare_tags.py
+++ b/taginfo_compare_tags.py
@@ -27,42 +27,45 @@ NC='\033[0m'
 parser.add_argument('--server', type=str, help='Does nothing')
 parser.add_argument('-o', '--output', type=str,  metavar='FILE',
                     help='Outputfile for plot (.png, ,jpg, .pdf)',
-                    default = "plot_" + str(datetime.datetime.now()) + ".png")
-parser.add_argument('--tag1', type=str, help='tag name', default = "waterway=riverbank")
-parser.add_argument('--tag2', type=str, help='tag name', default = "water=river")
-parser.add_argument('--level', type=int, help='Admin level (0..4)', default = "2")
-parser.add_argument('--color', type=str, help='Map color scale', default = "GR")
+                    default="plot_" + str(datetime.datetime.now()) + ".png")
+parser.add_argument('--tag1', type=str, help='tag name', default="waterway=riverbank")
+parser.add_argument('--tag2', type=str, help='tag name', default="water=river")
+parser.add_argument('--level', type=int, help='Admin level (0..4)', default="2")
+parser.add_argument('--color', type=str, help='Map color scale', default="GR")
 parser.add_argument('--csv', type=str,  metavar='FILE', required=False, default=None)
 parser.add_argument('--map', type=str,  metavar='FILE', required=False, default=None)
 
 args = parser.parse_args()
 
-with open('OSM_regions.json') as f: regions=json.load(f)
+with open('OSM_regions.json') as f:
+    regions = json.load(f)
+
 
 def recursive_regions(regions, max_lvl=args.level):
     output = []
-    is_rus = int(regions['name']=="Russia")
+    is_rus = int(regions['name'] == "Russia")
     # Since russia is so large, taginfo server treats it as separate continent.
-    if regions['admin_level']>=max_lvl-is_rus or not regions['subregions']:
-        iso=None
+    if regions['admin_level'] >= max_lvl-is_rus or not regions['subregions']:
+        iso = None
         if 'iso' in regions:
-            iso=regions['iso']
+            iso = regions['iso']
         return [(regions['name'], iso, regions['taginfo_url'])]
     for region in regions['subregions']:
-        output+=recursive_regions(region, max_lvl)
+        output += recursive_regions(region, max_lvl)
     return output
+
 
 # Process regions.json file. Recursively iterates over the tree and
 # returns list of taginfo servers to scan, in format (name, server_url)
 list_of_taginfo_servers = recursive_regions(regions, args.level)
 
 dict_of_country_codes = dict()
-f= csv.reader(open('sample list of countries.txt'))
+f = csv.reader(open('sample list of countries.txt'))
 for row in f:
     # Data sample: 53296,ME,Montenegro
     # print(row)
     rel_id, iso, name = row
-    dict_of_country_codes[name]=iso
+    dict_of_country_codes[name] = iso
 
 
 print("processing $csvlines countries")
@@ -72,37 +75,40 @@ print("------------------------------")
 # iso_a2 must be present because it's used for R mapping.
 output = [f"iso_a2,name,{args.tag1},{args.tag2}"]
 for region, iso, server in list_of_taginfo_servers:
-    if '=' in args.tag1: 
+    if '=' in args.tag1:
         url1 = server+'/api/4/tag/stats'
-        params1 = {'key':args.tag1.split('=')[0],'value':'='.join(args.tag1.split('=')[1:])}
+        params1 = {'key': args.tag1.split('=')[0],
+                   'value': '='.join(args.tag1.split('=')[1:])}
     else:
-        url1=server+'/api/4/key/stats'
-        params1 = {'key':args.tag1}
+        url1 = server+'/api/4/key/stats'
+        params1 = {'key': args.tag1}
     if '=' in args.tag2:
         url2 = server+'/api/4/tag/stats'
-        params2 = {'key':args.tag2.split('=')[0],'value':'='.join(args.tag2.split('=')[1:])}
+        params2 = {'key': args.tag2.split('=')[0],
+                   'value': '='.join(args.tag2.split('=')[1:])}
     else:
-        url2=server+'/api/4/key/stats'
-        params2 = {'key':args.tag2}
-    req_ok=False
-    failures=1
+        url2 = server+'/api/4/key/stats'
+        params2 = {'key': args.tag2}
+    req_ok = False
+    failures = 1
     while not req_ok:
-        resp1=requests.get(url1, params1)
-        resp2=requests.get(url2, params2)
-        if resp1.status_code !=200 or resp2.status_code !=200:
-            #print(resp1.content)
-            #print(resp2.content)
+        resp1 = requests.get(url1, params1)
+        resp2 = requests.get(url2, params2)
+        if resp1.status_code != 200 or resp2.status_code != 200:
+            # print(resp1.content)
+            # print(resp2.content)
             time.sleep(0.25*failures)
-        else:req_ok=True
-        failures+=1
+        else:
+            req_ok = True
+        failures += 1
         if failures % 4 == 0:
             print(f'Trying to contact taginfo at {url1}, attempt {failures}.')
-        
-    count1=list(filter(lambda x: x['type']=='all', resp1.json()['data']))[0]['count']
-    count2=list(filter(lambda x: x['type']=='all', resp2.json()['data']))[0]['count']
+
+    count1 = list(filter(lambda x: x['type'] == 'all', resp1.json()['data']))[0]['count']
+    count2 = list(filter(lambda x: x['type'] == 'all', resp2.json()['data']))[0]['count']
     print(f"[{iso} {region}]: {count1}, {count2}")
     if not iso:
-        iso='FIXME'
+        iso = 'FIXME'
         # Possible alternative to fix those fixmes: run overpass query for only those regions
     else:  # FIXME: Temp workaround to missing iso codes
         output.append(f"{iso},{region}, {count1}, {count2}")

--- a/taginfo_compare_tags.py
+++ b/taginfo_compare_tags.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# ./compare_tags_by_country.sh  --tag1 waterway=riverbank --tag2 water=river --map test2.png --server http://lz4.overpass-api.de --csv tag_compare.csv
+
+import requests
+import sys
+import datetime
+import argparse
+import json
+import time
+
+parser = argparse.ArgumentParser(description='Script for getting per-country tag counts via taginfo. Quicker alternative to compare_tags_by_country.sh')
+"""
+#defaults
+server=${server:-"http://lz4.overpass-api.de"}
+tag1=${tag1:-"waterway=riverbank"}
+tag2=${tag2:-"water=river"}
+color=${color:-"GR"}
+tmpcsv="/tmp/all_country_ids.csv"
+throttle=${throttle:-1}
+
+#color output codes
+YELLOW='\033[1;33m'
+NC='\033[0m'
+"""
+
+parser.add_argument('--server', type=str, help='Does nothing')
+parser.add_argument('-o', '--output', type=str,  metavar='FILE',
+                    help='Outputfile for plot (.png, ,jpg, .pdf)',
+                    default = "plot_" + str(datetime.datetime.now()) + ".png")
+parser.add_argument('--tag1', type=str, help='tag name', default = "waterway=riverbank")
+parser.add_argument('--tag2', type=str, help='tag name', default = "water=river")
+parser.add_argument('--level', type=int, help='Admin level (0..4)', default = "2")
+parser.add_argument('--color', type=str, help='Map color scale', default = "GR")
+parser.add_argument('--csv', type=str,  metavar='FILE', required=False, default=None)
+parser.add_argument('--map', type=str,  metavar='FILE', required=False, default=None)
+
+args = parser.parse_args()
+
+with open('OSM_regions.json') as f: regions=json.load(f)
+
+def recursive_regions(regions, max_lvl=args.level):
+    output = []
+    if regions['admin_level']>=max_lvl or not regions['subregions']:
+        return [(regions['name'], regions['taginfo_url'])]
+    for region in regions['subregions']:
+        output+=recursive_regions(region, max_lvl)
+    return output
+
+list_of_taginfo_servers = recursive_regions(regions, args.level)
+
+print("processing $csvlines countries")
+print(f"@[iso,name]: {args.tag1}, {args.tag2}")
+print("------------------------------")
+
+
+output = [f"iso,name,{args.tag1},{args.tag2}"]
+for region, server in list_of_taginfo_servers:
+    if '=' in args.tag1: 
+        url1 = server+'/api/4/tag/stats'
+        params1 = {'key':args.tag1.split('=')[0],'value':'='.join(args.tag1.split('=')[1:])}
+    else:
+        url1=server+'/api/4/key/stats'
+        params1 = {'key':args.tag1}
+    if '=' in args.tag2:
+        url2 = server+'/api/4/tag/stats'
+        params2 = {'key':args.tag2.split('=')[0],'value':'='.join(args.tag2.split('=')[1:])}
+    else:
+        url2=server+'/api/4/key/stats'
+        params2 = {'key':args.tag2}
+    req_ok=False
+    while not req_ok:
+        resp1=requests.get(url1, params1)
+        resp2=requests.get(url2, params2)
+        if resp1.status_code !=200 or resp2.status_code !=200:
+            #print(resp1.content)
+            #print(resp2.content)
+            time.sleep(0.25)
+        else:req_ok=True
+    count1=list(filter(lambda x: x['type']=='all', resp1.json()['data']))[0]['count']
+    count2=list(filter(lambda x: x['type']=='all', resp2.json()['data']))[0]['count']
+    print(f"[{region}]: {count1}, {count2}")
+    output.append(f"FIXME,{region}, {count1}, {count2}")
+    time.sleep(0.15)
+with open("/tmp/tags_all_countries.csv", 'w') as tmpcsv:
+    print('\n'.join(output), file=tmpcsv)
+if args.csv:
+    with open(args.csv, 'w') as csv:
+        print('\n'.join(output), file=csv)

--- a/taginfo_compare_tags.sh
+++ b/taginfo_compare_tags.sh
@@ -35,9 +35,6 @@ echo "Start processing at $date"
 echo
 
 
-wget -qO "$tmpcsv" --post-file=queries/all_country_ids.op \
-  "$server/api/interpreter"
-
 ./taginfo_compare_tags.py --level 2 --csv $tag_count_csv
 
 wgetreturn=$?

--- a/taginfo_compare_tags.sh
+++ b/taginfo_compare_tags.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+#command-line arguments
+while [ $# -gt 0 ]; do
+
+   if [[ $1 == *"--"* ]]; then
+        param="${1/--/}"
+        declare $param="$2"
+   fi
+
+  shift
+done
+
+#defaults
+server=${server:-"http://lz4.overpass-api.de"}
+tag1=${tag1:-"waterway=riverbank"}
+tag2=${tag2:-"water=river"}
+color=${color:-"GR"}
+tmpcsv="/tmp/all_country_ids.csv"
+tag_count_csv="/tmp/tags_all_countries.csv"
+throttle=${throttle:-1}
+
+#color output codes
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+
+
+date=`date`
+
+echo
+printf "Using ${YELLOW}taginfo.geofabrik servers${NC}\n"
+printf "Comparing ${YELLOW}${tag1}${NC} to ${YELLOW}${tag2}${NC} in each country\n"
+echo "Start processing at $date"
+echo
+
+
+wget -qO "$tmpcsv" --post-file=queries/all_country_ids.op \
+  "$server/api/interpreter"
+
+./taginfo_compare_tags.py --level 2 --csv $tag_count_csv
+
+wgetreturn=$?
+    if [[ $wgetreturn -ne 0 ]]; then
+        echo "Failed to read from overpass server at $server/api/interpreter; check the URL"
+	exit 1
+    fi
+
+
+csvoutput=$( cat $tag_count_csv )
+
+if [ ! -z "$map" ]
+then
+  echo -e "$csvoutput" | ./plot_overPass.R --tag1 "$tag1" --tag2 "$tag2" -o "$map" -c "$color"
+  printf "Saved map: ${YELLOW}${map}${NC}\n"
+fi
+
+if [ ! -z "$csv" ]
+then
+  echo -e "$csvoutput" > "$csv"
+  printf "Saved csv: ${YELLOW}${csv}${NC}\n"
+fi
+
+date=`date`
+echo
+echo "Finish processing at $date"
+printf 'Runtime: %02dh:%02dm:%02ds\n' $(($SECONDS/3600)) $(($SECONDS%3600/60)) $(($SECONDS%60))
+

--- a/taginfo_compare_tags.sh
+++ b/taginfo_compare_tags.sh
@@ -19,6 +19,7 @@ color=${color:-"GR"}
 tmpcsv="/tmp/all_country_ids.csv"
 tag_count_csv="/tmp/tags_all_countries.csv"
 throttle=${throttle:-1}
+noTaginfo="countries_wo_taginfo.txt"
 
 #color output codes
 YELLOW='\033[1;33m'
@@ -43,8 +44,33 @@ wgetreturn=$?
 	exit 1
     fi
 
+printf 'Runtime so far %02dh:%02dm:%02ds\n' $(($SECONDS/3600)) $(($SECONDS%3600/60)) $(($SECONDS%60))
+echo "Taginfo part finished, processing remaining $(wc -l < $noTaginfo) countries with overpass."
 
+# Python script wrote about 3/4 of tags into the csv file, but some countries are still not covered.
+# Those will be processed as part overpass requests
 csvoutput=$( cat $tag_count_csv )
+while read p; do
+  base_area=3600000000
+  rel_id="$( cut -d ',' -f 1 <<< "$p" )"
+  name="$( cut -d ',' -f 2- <<< "$p" )"
+  area_id=`expr $base_area + $rel_id`
+  query=`sed "s/#AREA/$area_id/g; s/#TAG1/$tag1/g; s/#TAG2/$tag2/g" queries/count_tags.op`
+  while [ -z "$counts" ]; do
+    counts=$(wget -qO- --post-data="$query" "$server/api/interpreter")
+    sleep "$throttle"
+  done
+  csvoutput="${csvoutput}\n${name},${counts}"
+  echo "[$name]: $counts"
+  name=
+  counts=
+
+
+done <"$noTaginfo"  # Load unprocessed countries
+
+#----------------------------
+
+
 
 if [ ! -z "$map" ]
 then


### PR DESCRIPTION
Main feature of this PR is  ` taginfo_compare_tags.py`, which contacts various taginfo websites to collect statistics. `taginfo_compare_tags.sh` is pretty much copy of `compare_tags_by_country.sh`, except way how it receives countries data has been reworked. 

`OSM_regions.json` and `countries_wo_taginfo.txt` are data files assisting new scripts to pick which countries should use taginfo and which ones can only be analysed by overpass. `sample list of countries.txt` is also used by script, it contains relation IDs, country names and ISO codes returned by overpass query. (That query is not included to this PR.)